### PR TITLE
Use old ApprovalTests to fix diff tool launch

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/node": "^14.14.37",
     "@typescript-eslint/eslint-plugin": "^4.27.0",
     "@typescript-eslint/parser": "^4.27.0",
-    "approvals": "^4.0.0-beta.1",
+    "approvals": "^3.0.5",
     "auto-plugin-obsidian": "^0.1.4",
     "eslint": "^7.29.0",
     "mocha": "^9.1.3",


### PR DESCRIPTION
This works around https://github.com/approvals/Approvals.NodeJS/issues/124