### PR TITLE
Add dependency "graphology-types"

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "fs": "0.0.1-security",
     "graphology": "^0.23.1",
     "graphology-traversal": "^0.2.2",
+    "graphology-types": "^0.23.0",
     "hierarchy-js": "^1.0.4",
     "juggl-api": "git+https://github.com/HEmile/juggl-api.git",
     "nodejs": "^0.0.0",


### PR DESCRIPTION
With this, I am able to run the tests with ts-moch on my Mac.

Also adds missing end-of-line at end, as WebStorm
insists on adding it.