### PR TITLE
Update styles.css

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -14,6 +14,11 @@
   text-align: left;
 }
 
+/* ensure empty headers not leaving an element  */
+.BC-Matrix .BC-Matrix-square .BC-Matrix-header:empty{
+	display: none;
+}
+
 .internal-link.BC-Link {
   color: var(--text-accent);
 }


### PR DESCRIPTION
Removes this small padding created by empty headers that occur when "show relationship type" is disabled. See video.

https://user-images.githubusercontent.com/73286100/148697214-c03e4338-2b3d-46f0-9d4d-6a79c08a5be9.mov

