### PR TITLE
Insert BC-trail as sibling of cm-contentContainer #435

### DIFF
--- a/src/Views/TrailView.ts
+++ b/src/Views/TrailView.ts
@@ -236,7 +236,7 @@ export async function drawTrail(plugin: BCPlugin): Promise<void> {
       //   })
       // }
 
-      view.querySelector("div.cm-contentContainer")?.firstChild?.before(trailDiv)
+      view.querySelector("div.cm-contentContainer")?.before(trailDiv)
 
     }
 


### PR DESCRIPTION
The bug https://github.com/SkepticMystic/breadcrumbs/issues/435 was due to `.BC-trail`'s parent `.cm-contentContainer` being `display: flex` (with default flex-direction of row)

This updates the trail UI to be inserted as a sibling of the display: flex .cm-contentContainer rather than a child of it.

This fixes both Source Mode and Live Preview mode

Before: 
![](https://camo.githubusercontent.com/39054feb538b43d48687b31409612ba035c9fc653f85d104494ac46a397787b6/68747470733a2f2f63646e2e7a617070792e6170702f37393835336365366461643861356331623336383931663763343139386530322e706e67)

After: 

![](https://camo.githubusercontent.com/110e98261978d72d0a5a64c31fd0e76bad9232b00592a43be16fd3a4fbe63fea/68747470733a2f2f63646e2e7a617070792e6170702f35633865643138633231346434643230613637393735363630616434363565612e706e67)

Resolves https://github.com/SkepticMystic/breadcrumbs/issues/435