### PR TITLE
Call addRibbonIcon earlier in onload() to avoid losing ribbon conf

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -140,6 +140,13 @@ export default class BCPlugin extends Plugin {
     addIcon(DUCK_ICON, DUCK_ICON_SVG);
     addIcon(TRAIL_ICON, TRAIL_ICON_SVG);
 
+    // addRibbonIcon must be before waitForCache(this); Otherwise the Ribbon configuration in Appearance/Ribbon menu/Manage is lost at every restart
+    this.addRibbonIcon(
+      addFeatherIcon("tv") as string,
+      "Breadcrumbs Visualisation",
+      () => new VisModal(this).open()
+    );
+
     await waitForCache(this);
     this.mainG = await buildMainG(this);
     this.closedG = buildClosedG(this);
@@ -262,12 +269,6 @@ export default class BCPlugin extends Plugin {
         callback: async () => await thread(this, field),
       });
     });
-
-    this.addRibbonIcon(
-      addFeatherIcon("tv") as string,
-      "Breadcrumbs Visualisation",
-      () => new VisModal(this).open()
-    );
 
     this.registerMarkdownCodeBlockProcessor(
       "breadcrumbs",


### PR DESCRIPTION
Hello @SkepticMystic, 
Thanks for this great plugin. 
It seems you are busy with other projects, so I tried to fix a small bug to help. 
I saw more important bugs out there but it's my first opensource contribution, so I start small.

### Bug description
The TV icon for the Breadcrumb visualisation on the left ribbon is always **visible** and **last** at the bottom of the list.
Changing its position or visibility in Obsidian "settings -> Appearance -> Ribbon menu -> Manage" stays only **until** Obsidian is restarted.

### Fix description
I don't know exactly how it works but through trial and error I discovered that calling addRibbonIcon() before function waitForCache() fixes the problem. 
I suppose waiting for dataview plugin to be ready then calling addRibbonIcon() is messing up with the ribbon saved state.

### Releasing
I hope you will merge this PR and be able to deliver a new minor version of the plugin.
I did not commit the main.js file because there are lot diff generated that I don't really know where it comes from.
That does not seem safe that a developer commit itself the "binary" code. 
Is there some pipeline to deliver it after merge ?

Thanks

