### PR TITLE
fix(view:page): Redraw the Page Views on all markdown views, not just the active one

### DIFF
--- a/src/components/page_views/PrevNextView.svelte
+++ b/src/components/page_views/PrevNextView.svelte
@@ -1,20 +1,19 @@
 <script lang="ts">
+	import { has_edge_attrs } from "src/graph/utils";
 	import BreadcrumbsPlugin from "src/main";
-	import { active_file_store } from "src/stores/active_file";
 	import { group_by } from "src/utils/arrays";
 	import EdgeLink from "../EdgeLink.svelte";
-	import { has_edge_attrs } from "src/graph/utils";
 
 	export let plugin: BreadcrumbsPlugin;
+	export let file_path: string;
 
 	const grouped_out_edges =
-		$active_file_store &&
 		// Even tho we ensure the graph is built before the views are registered,
 		// Existing views still try render before the graph is built.
-		plugin.graph.hasNode($active_file_store.path)
+		plugin.graph.hasNode(file_path)
 			? group_by(
 					plugin.graph
-						.get_out_edges($active_file_store.path)
+						.get_out_edges(file_path)
 						.filter((e) =>
 							has_edge_attrs(e, { $or_dirs: ["prev", "next"] }),
 						),

--- a/src/components/page_views/TrailView.svelte
+++ b/src/components/page_views/TrailView.svelte
@@ -2,24 +2,23 @@
 	import { Traverse } from "src/graph/traverse";
 	import { has_edge_attrs } from "src/graph/utils";
 	import type BreadcrumbsPlugin from "src/main";
-	import { active_file_store } from "src/stores/active_file";
 	import { remove_duplicates_by } from "src/utils/arrays";
 	import TrailViewGrid from "./TrailViewGrid.svelte";
 	import TrailViewPath from "./TrailViewPath.svelte";
 
 	export let plugin: BreadcrumbsPlugin;
+	export let file_path: string;
 
 	const all_paths =
-		$active_file_store &&
 		// Even tho we ensure the graph is built before the views are registered,
 		// Existing views still try render before the graph is built.
-		plugin.graph.hasNode($active_file_store.path)
+		plugin.graph.hasNode(file_path)
 			? plugin.settings.hierarchies
 					.map((_hierarchy, hierarchy_i) =>
 						Traverse.all_paths(
 							"depth_first",
 							plugin.graph,
-							$active_file_store!.path,
+							file_path,
 							(edge) =>
 								has_edge_attrs(edge, {
 									dir: "up",

--- a/src/components/page_views/index.svelte
+++ b/src/components/page_views/index.svelte
@@ -4,6 +4,8 @@
 	import TrailView from "./TrailView.svelte";
 
 	export let plugin: BreadcrumbsPlugin;
+	// NOTE: We can't rely on $active_file_store, since there may be multiple notes open at once, only one of which is active
+	export let file_path: string;
 
 	const enabled_views = {
 		grid: plugin.settings.views.page.trail.enabled,
@@ -14,11 +16,11 @@
 {#if Object.values(enabled_views).some(Boolean)}
 	<div class="markdown-rendered mb-4">
 		{#if enabled_views.grid}
-			<TrailView {plugin} />
+			<TrailView {plugin} {file_path} />
 		{/if}
 
 		{#if enabled_views.prev_next}
-			<PrevNextView {plugin} />
+			<PrevNextView {plugin} {file_path} />
 		{/if}
 	</div>
 {/if}

--- a/src/views/page.ts
+++ b/src/views/page.ts
@@ -1,68 +1,81 @@
 import { MarkdownView } from "obsidian";
-import PageViews from "src/components/page_views/index.svelte";
+import PageViewsComponent from "src/components/page_views/index.svelte";
 import { log } from "src/logger";
 import type BreadcrumbsPlugin from "src/main";
 
 export const redraw_page_views = (plugin: BreadcrumbsPlugin) => {
-	const markdown_view =
-		plugin.app.workspace.getActiveViewOfType(MarkdownView);
-	if (!markdown_view) {
-		return log.info("redraw_page_views > No active markdown view");
+	const markdown_views = plugin.app.workspace.getLeavesOfType("markdown");
+	if (!markdown_views.length) {
+		log.info("redraw_page_views > No markdown views found");
+		return;
 	}
 
-	const markdown_view_mode = markdown_view.getMode();
+	markdown_views.forEach((leaf) => {
+		if (!(leaf.view instanceof MarkdownView)) return;
 
-	// Ensure the container exists _on the current page_, leaving other pages' containers alone
-	const page_views_el =
-		markdown_view.containerEl.querySelector(".BC-page-views") ??
-		markdown_view.containerEl.createDiv({
-			cls: "BC-page-views w-full mx-auto",
-		});
+		const markdown_view = leaf.view;
+		const mode = markdown_view.getMode();
 
-	// Set the max width
-	// NOTE: Do this _after_ getting the element
-	//   So that if it existed already, it gets updated
-	const max_width = plugin.settings.views.page.all.readable_line_width
-		? "var(--file-line-width)"
-		: "none";
-	page_views_el.setAttribute("style", `max-width: ${max_width};`);
+		// Ensure the container exists _on the current page_, leaving other pages' containers alone
+		const page_views_el =
+			markdown_view.containerEl.querySelector(".BC-page-views") ??
+			markdown_view.containerEl.createDiv({
+				cls: "BC-page-views w-full mx-auto",
+			});
 
-	// Stickyness
-	page_views_el.classList.toggle(
-		"BC-page-views-sticky",
-		plugin.settings.views.page.all.sticky,
-	);
+		// Set the max width
+		// NOTE: Do this _after_ getting the element
+		//   So that if it existed already, it gets updated
+		const max_width = plugin.settings.views.page.all.readable_line_width
+			? "var(--file-line-width)"
+			: "none";
+		page_views_el.setAttribute("style", `max-width: ${max_width};`);
 
-	// Clear out any old content
-	page_views_el.empty();
-
-	// Move it to the right place
-	if (markdown_view_mode === "preview") {
-		// NOTE: Embedded notes also match ".markdown-preview-view", so instead
-		//   we ensure the immediate parent is ".markdown-reading-view", which doesn't
-		//   exist on embedded notes
-		const view_parent = markdown_view.containerEl.querySelector(
-			".markdown-reading-view > .markdown-preview-view",
+		// Stickyness
+		page_views_el.classList.toggle(
+			"BC-page-views-sticky",
+			plugin.settings.views.page.all.sticky,
 		);
-		if (!view_parent) return log.info("redraw_page_views > No view_parent");
 
-		view_parent.insertBefore(page_views_el, view_parent.firstChild);
-	} else {
-		const view_parent =
-			markdown_view.containerEl.querySelector(".cm-scroller");
-		if (!view_parent) return log.info("redraw_page_views > No view_parent");
+		// Clear out any old content
+		page_views_el.empty();
 
-		// See here for an in-depth discussion on why it's done this way:
-		// https://discord.com/channels/686053708261228577/931552763467411487/1198377191994564621
-		// But basically, this shouldn't affect anything, and it's by far the easiest way to do it
-		view_parent.addClass("flex-col");
+		// Move it to the right place
+		if (mode === "preview") {
+			// NOTE: Embedded notes also match ".markdown-preview-view", so instead
+			//   we ensure the immediate parent is ".markdown-reading-view", which doesn't
+			//   exist on embedded notes
+			const view_parent = markdown_view.containerEl.querySelector(
+				".markdown-reading-view > .markdown-preview-view",
+			);
+			if (!view_parent) {
+				return log.info(
+					"redraw_page_views > No view_parent (mode=preview)",
+				);
+			}
 
-		view_parent.insertBefore(page_views_el, view_parent.firstChild);
-	}
+			view_parent.insertBefore(page_views_el, view_parent.firstChild);
+		} else {
+			const view_parent =
+				markdown_view.containerEl.querySelector(".cm-scroller");
+			if (!view_parent) {
+				return log.info(
+					"redraw_page_views > No view_parent (mode=source)",
+				);
+			}
 
-	// Render the component into the container
-	new PageViews({
-		target: page_views_el,
-		props: { plugin },
+			// See here for an in-depth discussion on why it's done this way:
+			// https://discord.com/channels/686053708261228577/931552763467411487/1198377191994564621
+			// But basically, this shouldn't affect anything, and it's by far the easiest way to do it
+			view_parent.addClass("flex-col");
+
+			view_parent.insertBefore(page_views_el, view_parent.firstChild);
+		}
+
+		// Render the component into the container
+		new PageViewsComponent({
+			target: page_views_el,
+			props: { plugin, file_path: markdown_view.file?.path ?? "" },
+		});
 	});
 };


### PR DESCRIPTION
1. Don't just redraw the Page View on the _axtive_ markdown editor, redraw on all
2. Because of this, we can no longer rely on `$active_file_store`, since the Page View being drawn may not be for the active file. So instead, pass in the `file_path` of the markdown view