### PR TITLE
Fix Breadcrumbs not detecting frontmatter tags for Tag Notes Explicit Edge Builder

### DIFF
--- a/src/graph/builders/explicit/tag_note.ts
+++ b/src/graph/builders/explicit/tag_note.ts
@@ -84,16 +84,22 @@ export const _add_explicit_edges_tag_note: ExplicitEdgeBuilder = (
 		({ file: tag_note_file, cache: tag_note_cache }) => {
 			if (!tag_note_cache) return;
 
-			// Check if the tag_note itself has any tags for other tags notes
-			tag_note_cache?.tags?.forEach(({ tag }) => {
+			const process_tag = ( tag: string) => {
+				// Ensure consistent tag formatting, since some have the # and some don't
+				const formatted_tag = tag[0] === "#" ? tag : "#" + tag
 				// Quite happy with this trick :)
 				// Try get the existing_paths, and mutate it if it exists
 				// Push returns the new length (guarenteed to be atleast 1 - truthy)
 				// So it will only be false if the key doesn't exist
-				if (!tag_paths_map.get(tag)?.push(tag_note_file.path)) {
-					tag_paths_map.set(tag, [tag_note_file.path]);
+				if (!tag_paths_map.get(formatted_tag)?.push(tag_note_file.path)) {
+					tag_paths_map.set(formatted_tag, [tag_note_file.path]);
 				}
-			});
+			}
+
+			// Check if the tag_note itself has any tags for other tags notes
+			// We must iterate over both the frontmatter and body tags independently
+			tag_note_cache?.frontmatter?.tags?.forEach(process_tag);
+			tag_note_cache?.tags?.map((item) => item.tag)?.forEach(process_tag)
 
 			const tag_note_info = get_tag_note_info(
 				plugin,
@@ -102,7 +108,7 @@ export const _add_explicit_edges_tag_note: ExplicitEdgeBuilder = (
 			);
 			if (!tag_note_info.ok) {
 				if (tag_note_info.error) errors.push(tag_note_info.error);
-				return;
+				return { errors };
 			}
 
 			const { tag, field, exact } = tag_note_info.data;
@@ -133,7 +139,7 @@ export const _add_explicit_edges_tag_note: ExplicitEdgeBuilder = (
 		);
 		if (!tag_note_info.ok) {
 			if (tag_note_info.error) errors.push(tag_note_info.error);
-			return;
+			return { errors };
 		}
 		const { tag, field, exact } = tag_note_info.data;
 


### PR DESCRIPTION
Fixes issue where Breadcrumbs could not detect tags in the frontmatter when building edges from tag notes. Fixes the issue I was having that I mentioned in #568, although I'm unsure if it fixes the problem the original issue creator was having.

Basically, it seems Obsidian may have updated their API, and frontmatter and body notes now appear in different formats and in different portions of the data, so it is necessary to check both. This also requires standardizing the formatting (whether to include the `#` in the string), since in frontmatter, Obsidian accepts either and displays them identically, but does not pass them to plugins identically.

I also added proper returning of errors in a couple of spots, since otherwise those return statements will just return `undefined`.