### PR TITLE
fix: Correctly detect explicit edges in `freeze_implied_edges_to_note`

### DIFF
--- a/src/commands/freeze_edges/index.ts
+++ b/src/commands/freeze_edges/index.ts
@@ -15,7 +15,7 @@ export async function freeze_implied_edges_to_note(
 		.get_edges()
 		.filter(
 			// Don't freeze a note to itself (self_is_sibling)
-			(e) => !e.is_self_loop() && !e.explicit,
+			(e) => !e.is_self_loop() && !e.explicit(plugin.graph),
 		);
 
 	await drop_crumbs(plugin, source_file, implied_edges, options);


### PR DESCRIPTION
Fixes a small oversight that caused the "Freeze implied edges to note" to stop working.