### PR TITLE
chore: add exempt issue labels

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,3 +22,4 @@ jobs:
           days-before-issue-close: 10
           days-before-pr-close: 10
           exempt-assignees: SkepticMystic,michaelpporter
+          exempt-issue-labels: 'Considering'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "breadcrumbs",
-	"version": "4.3.3-beta",
+	"version": "4.3.6-beta",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "breadcrumbs",
-			"version": "4.3.3-beta",
+			"version": "4.3.6-beta",
 			"license": "MIT",
 			"dependencies": {
 				"lucide-svelte": "^0.537.0",


### PR DESCRIPTION
This pull request makes a minor update to the `.github/workflows/stale.yml` workflow configuration. The change adds an exemption for issues labeled 'Considering', preventing them from being automatically closed by the stale bot.

* Workflow configuration update:
  * Added `exempt-issue-labels: 'Considering'` to prevent issues with this label from being closed by the stale bot.