### PR TITLE
Leverage existing sorted date notes to construct file path to next date note

### DIFF
--- a/src/graph/builders/explicit/date_note.ts
+++ b/src/graph/builders/explicit/date_note.ts
@@ -116,9 +116,9 @@ export const _add_explicit_edges_date_note: ExplicitEdgeBuilder = (
 				? (next_date_note_basename ?? basename_plus_one_day)
 				: basename_plus_one_day;
 			log.debug(`tomorrow_folder: ${tomorrow_folder}`);
-			const target_path = (date_note_settings.stretch_to_existing || target_basename === next_date_note_basename) ? (next_date_note_folder ?? tomorrow_folder) : tomorrow_folder;
+			const target_folder = (date_note_settings.stretch_to_existing || target_basename === next_date_note_basename) ? (next_date_note_folder ?? tomorrow_folder) : tomorrow_folder;
 			const target_id = Paths.build(
-				target_path,
+				target_folder,
 				target_basename,
 				date_note.ext,
 			);


### PR DESCRIPTION
Fix for #651 

The fix aims at leveraging the folder field in existing sorted date notes and avoid using the constructed `tomorrow_folder` whenever possible. Specifically:

1. When stretching is enabled, always try using next date note's folder
2. When stretching is disabled, try using next date note's folder if and only if next date note's basename is the same as the `target_basename`
3. In all other cases and when next date note's folder is undefined, fallback and use `tomorrow_folder` instead


I think this is logically correct while preserving the default way of constructing `tomorrow_folder`. I avoided changing the replacement logic to construct `tomorrow_folder` in [src/graph/builders/explicit/date_note.ts # line 98](https://github.com/SkepticMystic/breadcrumbs/blob/44de27889cfeadfbd1829cc404993acf6243bca0/src/graph/builders/explicit/date_note.ts#L98), which is based on the assumption that the year format in the folder path is `yyyy`. This is incompatible with short year format `yy`.
