### PR TITLE
Bug fix - incorrect link display in last date note

### DIFF
--- a/src/graph/builders/explicit/date_note.ts
+++ b/src/graph/builders/explicit/date_note.ts
@@ -110,8 +110,8 @@ export const _add_explicit_edges_date_note: ExplicitEdgeBuilder = (
 			}
 
 			const next_date_note = date_notes.at(i + 1);
-			const next_date_note_folder = next_date_note?.folder ?? "";
-			const next_date_note_basename = next_date_note?.basename ?? "";
+			const next_date_note_folder = next_date_note?.folder;
+			const next_date_note_basename = next_date_note?.basename;
 			const target_basename = date_note_settings.stretch_to_existing
 				? (next_date_note_basename ?? basename_plus_one_day)
 				: basename_plus_one_day;


### PR DESCRIPTION
Fix the display error of the next date note field in the last date note in vault. Currently it displays ".md" due to my previous mistake of setting the basename and folder to an empty string instead of leaving it undefined ([Line 113 and 114 of src/graph/builders/explicit/date_note.ts](https://github.com/SkepticMystic/breadcrumbs/blob/1cd9b484e4c79a8f01cd3c426afb80a824006307/src/graph/builders/explicit/date_note.ts#L113))



This bug was introduced in my previous PR #652 