### PR TITLE
feat: add depth selector to tree view and toggle sticky page views

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -13,6 +13,7 @@ import { freeze_implied_edges_to_note } from "./freeze_edges";
 import { jump_to_neighbour } from "./jump";
 import { get_graph_stats } from "./stats";
 import { thread } from "./thread";
+import { redraw_page_views } from "src/views/page";
 
 export function init_all_commands(plugin: BreadcrumbsPlugin) {
 	plugin.addCommand({
@@ -159,5 +160,19 @@ export function init_all_commands(plugin: BreadcrumbsPlugin) {
 					plugin.settings.commands.thread.default_options,
 				),
 		});
+	});
+
+	plugin.addCommand({
+		id: "breadcrumbs:toggle-sticky-page-views",
+		name: "Toggle sticky page views",
+		callback: async () => {
+			plugin.settings.views.page.all.sticky =
+				!plugin.settings.views.page.all.sticky;
+			await plugin.saveSettings();
+			redraw_page_views(plugin);
+			new Notice(
+				`Page views sticky: ${plugin.settings.views.page.all.sticky ? "on" : "off"}`,
+			);
+		},
 	});
 }

--- a/src/components/side_views/TreeView.svelte
+++ b/src/components/side_views/TreeView.svelte
@@ -96,6 +96,11 @@
 
 	let active_file = $derived($active_file_store);
 
+	let depth = $state(0);
+	$effect(() => {
+		depth = settings.default_depth;
+	});
+
 	let tree: FlatTraversalResult | undefined = $derived.by(() => {
 		if (active_file && plugin.graph.has_node(active_file.path)) {
 			let entry_path = active_file.path;
@@ -112,7 +117,7 @@
 				new TraversalOptions(
 					[entry_path],
 					edge_field_labels,
-					5,
+					depth,
 					100,
 					settings.merge_fields,
 					undefined,
@@ -180,6 +185,32 @@
 				edge_field_groups={plugin.settings.edge_field_groups}
 				bind:field_group_labels={settings.field_group_labels}
 			/>
+
+			<div class="flex items-center gap-1">
+				<button
+					class="clickable-icon nav-action-button aspect-square text-lg"
+					aria-label="Decrease max depth"
+					disabled={depth <= 1}
+					onclick={() => (depth = Math.max(1, depth - 1))}
+				>
+					-
+				</button>
+
+				<span
+					class="font-mono text-sm"
+					aria-label={tree?.hit_depth_limit ? "Some nodes have been truncated" : ""}
+				>
+					{depth}{tree?.hit_depth_limit ? "+" : ""}
+				</span>
+
+				<button
+					class="clickable-icon nav-action-button aspect-square text-lg"
+					aria-label="Increase max depth"
+					onclick={() => (depth = depth + 1)}
+				>
+					+
+				</button>
+			</div>
 		</div>
 	</div>
 

--- a/src/const/settings.ts
+++ b/src/const/settings.ts
@@ -198,6 +198,7 @@ export const DEFAULT_SETTINGS: BreadcrumbsSettings = {
 				collapse: false,
 				show_attributes: [],
 				merge_fields: false,
+				default_depth: 5,
 				lock_view: false,
 				lock_path: "",
 				// Include `ups` so Dendron hierarchy (default field `up`) shows parents in the tree.

--- a/src/interfaces/settings.ts
+++ b/src/interfaces/settings.ts
@@ -153,6 +153,7 @@ export interface BreadcrumbsSettings {
 			tree: {
 				collapse: boolean;
 				merge_fields: boolean;
+				default_depth: number;
 				edge_sort_id: EdgeSortId;
 				field_group_labels: string[];
 				show_attributes: EdgeAttribute[];

--- a/tests/settings/migration.test.ts
+++ b/tests/settings/migration.test.ts
@@ -264,6 +264,7 @@ describe("migration", () => {
 					tree: {
 						collapse: true,
 						merge_fields: false,
+						default_depth: 5,
 						lock_view: false,
 						lock_path: "",
 						show_attributes: [],
@@ -497,6 +498,7 @@ describe("migration", () => {
 							order: 1,
 						},
 						merge_fields: false,
+						default_depth: 5,
 						lock_view: false,
 						lock_path: "",
 						field_group_labels: ["ups", "downs"],


### PR DESCRIPTION
Addresses: #524 

* Introduce a depth setting for the tree view, allowing users to adjust the maximum depth of displayed nodes.
* Add buttons to increase or decrease the depth dynamically.
* Update settings interface to include default depth configuration.
* Implement a command to toggle sticky page views, enhancing user experience with persistent view settings.