### PR TITLE
docs: fix typo in V4.md

### DIFF
--- a/V4.md
+++ b/V4.md
@@ -12,7 +12,7 @@ You can start using V4 right now by installing it with the BRAT plugin
 
 > [!TIP]
 > There are still some logs enabled in these early stages.
-> One particularly helpful log happens everytime you rebuild the graph, and are prefixed with `explicit_edge_results`. These logs tell you any warnings/errors that occured when rebuilding the graph, and which file had the error.
+> One particularly helpful log happens everytime you rebuild the graph, and are prefixed with `explicit_edge_results`. These logs tell you any warnings/errors that occurred when rebuilding the graph, and which file had the error.
 
 ## Changes
 


### PR DESCRIPTION
## Summary

Single-word typo fix in `V4.md`: `occured` -> `occurred`.

## Verification

- `grep -n 'occured' V4.md` returns 0 matches after fix.
- No other occurrences of this typo in the repo.

## Note

Co-developed with AI assistance; reviewed and tested by submitter.