### PR TITLE
feat(edge_fields): per-field "Hide in views" toggle

### DIFF
--- a/src/components/settings/EdgeFieldSettings.svelte
+++ b/src/components/settings/EdgeFieldSettings.svelte
@@ -88,6 +88,38 @@
 					);
 				});
 
+				// Drop transitive rules that reference the removed field —
+				// unlike rename, there's no replacement label to substitute.
+				settings.implied_relations.transitive =
+					settings.implied_relations.transitive.filter(
+						(rule) =>
+							rule.close_field !== edge_field.label &&
+							!rule.chain.some(
+								(attr) => attr.field === edge_field.label,
+							),
+					);
+
+				// Clear any edge source default pointing at the removed field.
+				const sources = settings.explicit_edge_sources;
+				if (sources.tag_note.default_field === edge_field.label)
+					sources.tag_note.default_field = "";
+				if (
+					sources.list_note.default_neighbour_field ===
+					edge_field.label
+				)
+					sources.list_note.default_neighbour_field = "";
+				if (sources.dendron_note.default_field === edge_field.label)
+					sources.dendron_note.default_field = "";
+				if (
+					sources.johnny_decimal_note.default_field ===
+					edge_field.label
+				)
+					sources.johnny_decimal_note.default_field = "";
+				if (sources.date_note.default_field === edge_field.label)
+					sources.date_note.default_field = "";
+				if (sources.regex_note.default_field === edge_field.label)
+					sources.regex_note.default_field = "";
+
 				autosave();
 			},
 

--- a/src/components/settings/EdgeFieldSettings.svelte
+++ b/src/components/settings/EdgeFieldSettings.svelte
@@ -186,6 +186,17 @@
 
 				autosave();
 			},
+
+			set_hidden: (edge_field: EdgeField, hidden: boolean) => {
+				const target = settings.edge_fields.find(
+					(f) => f.label === edge_field.label,
+				);
+				if (!target) return;
+
+				target.hide_in_views = hidden || undefined;
+
+				autosave();
+			},
 		},
 
 		groups: {
@@ -459,6 +470,22 @@
 							<option value={arrow}>{arrow}</option>
 						{/each}
 					</select>
+
+					<label
+						class="flex items-center gap-1"
+						title="Hide this field from the Matrix and Tree side views"
+					>
+						<input
+							type="checkbox"
+							checked={field.hide_in_views ?? false}
+							onchange={(e) =>
+								actions.fields.set_hidden(
+									field,
+									e.currentTarget.checked,
+								)}
+						/>
+						Hide in views
+					</label>
 
 					{#each group_labels as group_label}
 						<Tag

--- a/src/components/side_views/Matrix.svelte
+++ b/src/components/side_views/Matrix.svelte
@@ -2,7 +2,10 @@
 	import type { BreadcrumbsSettings } from "src/interfaces/settings";
 	import type BreadcrumbsPlugin from "src/main";
 	import { active_file_store } from "src/stores/active_file";
-	import { resolve_field_group_labels } from "src/utils/edge_fields";
+	import {
+		omit_hidden_view_fields,
+		resolve_field_group_labels,
+	} from "src/utils/edge_fields";
 	import { create_edge_sorter } from "wasm/pkg/breadcrumbs_graph_wasm";
 	import ChevronCollapseButton from "../button/ChevronCollapseButton.svelte";
 	import LockViewButton from "../button/LockViewButton.svelte";
@@ -62,9 +65,12 @@
 	});
 
 	let edge_field_labels = $derived(
-		resolve_field_group_labels(
-			plugin.settings.edge_field_groups,
-			settings.field_group_labels,
+		omit_hidden_view_fields(
+			plugin.settings.edge_fields,
+			resolve_field_group_labels(
+				plugin.settings.edge_field_groups,
+				settings.field_group_labels,
+			),
 		),
 	);
 

--- a/src/components/side_views/TreeView.svelte
+++ b/src/components/side_views/TreeView.svelte
@@ -2,7 +2,10 @@
 	import type { BreadcrumbsSettings } from "src/interfaces/settings";
 	import type BreadcrumbsPlugin from "src/main";
 	import { active_file_store } from "src/stores/active_file";
-	import { resolve_field_group_labels } from "src/utils/edge_fields";
+	import {
+		omit_hidden_view_fields,
+		resolve_field_group_labels,
+	} from "src/utils/edge_fields";
 	import NestedEdgeList from "../NestedEdgeList.svelte";
 	import ChevronCollapseButton from "../button/ChevronCollapseButton.svelte";
 	import ChevronOpener from "../button/ChevronOpener.svelte";
@@ -98,9 +101,12 @@
 	});
 
 	let edge_field_labels = $derived(
-		resolve_field_group_labels(
-			plugin.settings.edge_field_groups,
-			settings.field_group_labels,
+		omit_hidden_view_fields(
+			plugin.settings.edge_fields,
+			resolve_field_group_labels(
+				plugin.settings.edge_field_groups,
+				settings.field_group_labels,
+			),
 		),
 	);
 

--- a/src/interfaces/settings.ts
+++ b/src/interfaces/settings.ts
@@ -20,6 +20,7 @@ export type MermaidArrowType = (typeof MERMAID_ARROW_TYPES)[number];
 export interface EdgeField {
 	label: string;
 	mermaid_arrow?: MermaidArrowType;
+	hide_in_views?: boolean;
 }
 export interface EdgeFieldGroup {
 	label: string;

--- a/src/utils/edge_fields.ts
+++ b/src/utils/edge_fields.ts
@@ -10,3 +10,13 @@ export const resolve_field_group_labels = (
 			.filter((group) => field_group_labels.includes(group.label))
 			.flatMap((group) => group.fields),
 	);
+
+export const omit_hidden_view_fields = (
+	edge_fields: BreadcrumbsSettings["edge_fields"],
+	labels: string[],
+) => {
+	const hidden = new Set(
+		edge_fields.filter((f) => f.hide_in_views).map((f) => f.label),
+	);
+	return labels.filter((l) => !hidden.has(l));
+};


### PR DESCRIPTION
## Summary

Adds a per-field **Hide in views** toggle so an edge field can be kept in groups, codeblocks, and the graph yet suppressed from the Matrix and Tree side views. Resolves the last loose end (item 3) from discussion #132's UI audit.

Also fixes a latent consistency bug surfaced while auditing the field settings: removing a field left dangling references that `rename` already cleaned.

## Changes

- **`EdgeField.hide_in_views?: boolean`** (`src/interfaces/settings.ts`) — optional, so existing fields default to visible. No settings migration needed.
- **`omit_hidden_view_fields()`** (`src/utils/edge_fields.ts`) — filters hidden labels out of a resolved field set.
- **Matrix + Tree** (`src/components/side_views/{Matrix,TreeView}.svelte`) — wrap the resolved `edge_field_labels` in the new filter. Tree's `find_root` field set is left unfiltered (structural, not display).
- **Settings UI** (`src/components/settings/EdgeFieldSettings.svelte`) — "Hide in views" checkbox per field + `set_hidden` action (stores `true` / clears the key when off).
- **Remove cascade fix** (same file) — `remove()` now drops transitive rules whose `chain[].field` or `close_field` reference the deleted label, and clears any `explicit_edge_sources.*.default_field` pointing at it. Previously these dangled (a stale `close_field` could even surface a phantom field in views).

## Scope

Side views only. Codeblocks (explicit `fields:` whitelist) and page views (Trail/PrevNext) are unaffected by the toggle.

## Test plan

- `tsc -noEmit`, `svelte-check`, `vitest` (259 tests) — all green.
- Manual: toggle "Hide in views" on a field → drops from Matrix + Tree; still works in a `breadcrumbs` codeblock with `fields: [<field>]`; untoggle restores. Remove a field used as a source `default_field` and in a transitive rule → rule dropped, source default cleared, no phantom field.