### PR TITLE
Default trail grid selection to "longest"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* The trail view's grid format now defaults its path selection to **`longest`**. Date notes (and any note with skip-level "shortcut" edges) link up to every ancestor level at once, so the old `all` default drew every redundant path and the grid read as a cluttered fan of repeated ancestors. `longest` keeps only the deepest chain — e.g. `2026 → 2026-Q2 → 2026-06 → 2026-W26` — so the trail reads as a clean tree. Existing trails keep their saved selection; switch via the trail's selection dropdown.
+
 ## 4.X
 
 ### [4.19.2](https://github.com/michaelpporter/breadcrumbs/compare/4.19.1...4.19.2) (2026-06-27)

--- a/src/const/settings.ts
+++ b/src/const/settings.ts
@@ -169,7 +169,7 @@ export const DEFAULT_SETTINGS: BreadcrumbsSettings = {
 			trail: {
 				enabled: true,
 				format: "grid",
-				selection: "all",
+				selection: "longest",
 				default_depth: 999,
 				no_path_message: "",
 				show_controls: true,

--- a/tests/settings/migration.test.ts
+++ b/tests/settings/migration.test.ts
@@ -59,7 +59,8 @@ describe("migration", () => {
 					},
 				},
 				views: {
-					page: { trail: { show_controls: false } },
+					// selection: preserved from the fixture; default is now "longest"
+					page: { trail: { show_controls: false, selection: "all" } },
 					side: {
 						matrix: { show_node_options: { ext: true } },
 						tree: { collapse: true },
@@ -92,7 +93,8 @@ describe("migration", () => {
 
 		expect(migrated).toStrictEqual(
 			with_defaults({
-				views: { page: { trail: { format: "path" } } },
+				// selection: preserved from the fixture; default is now "longest"
+				views: { page: { trail: { format: "path", selection: "all" } } },
 				commands: {
 					list_index: {
 						default_options: {


### PR DESCRIPTION
Change the trail view's grid format to default its path selection to "longest," ensuring a cleaner representation of the trail by displaying only the deepest chain. Existing trails retain their saved selection, and migration preserves this change.