### PR TITLE
refactor: architecture review — codeblock source resolution, builder field-validation, tree entry-paths

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,15 +1,4 @@
 # These are supported funding model platforms
 
 github: [michaelpporter] # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
-patreon: # Replace with a single Patreon username
-open_collective: # Replace with a single Open Collective username
-ko_fi: # Replace with a single Ko-fi username
-tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
-liberapay: # Replace with a single Liberapay username
-issuehunt: # Replace with a single IssueHunt username
-lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
-polar: # Replace with a single Polar username
 buy_me_a_coffee: michaelpporter # Replace with a single Buy Me a Coffee username
-thanks_dev: # Replace with a single thanks.dev username
-custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -169,6 +169,30 @@ review:**
 
 ---
 
+## `dataview_from_query` — parser/evaluator fusion, deliberately not split
+
+`src/codeblocks/dataview_from.ts` parses a Dataview-style `from` query
+(`#tag`, `"folder"`, `[[link]]`, `AND`/`OR`/`NOT`) straight into `FilePredicate`
+closures rather than an intermediate AST — parsing and evaluation are one
+step. Flagged in the 2026-06-24 review as a shallow-abstraction candidate;
+checked during the 2026-07-01 follow-up and **not split**: it has exactly one
+real consumer (the codeblock `from` field, called identically from
+`index.ts` and all three codeblock components for the same feature) — no
+second adapter to justify the seam. Don't re-propose the AST split unless a
+genuinely distinct second consumer shows up.
+
+Also traced: no branch in `parse_atom`/`parse_and`/`parse_or`/`consume_keyword`
+can throw — an unrecognised atom returns a false-matching predicate, not an
+exception. The `try`/`catch` in `try_dataview_from_query` and the parse-time
+validation in `codeblocks/index.ts` guard against an exception this grammar
+structurally can't produce today. Harmless as-is; know this before "fixing"
+error handling here.
+
+Test coverage added instead (`tests/codeblocks/dataview_from.test.ts`) — the
+file had none before.
+
+---
+
 ## Owned WASM lifecycle (`useOwned`)
 
 `src/stores/use_owned.svelte.ts` — a rune helper that owns a derived WASM

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -101,6 +101,42 @@ directly (9 cases: guards, each branch, precedence, fallthroughs).
 
 ---
 
+## Codeblock source resolution
+
+`resolve_codeblock_source` + `validate_codeblock_entry`
+(`src/codeblocks/resolve_codeblock_source.ts`) — the `source_path`/`max_depth`
+arithmetic and `has_node` validation shared by all three codeblock types
+(Tree, Mermaid, Markmap): `start-note` override → the codeblock's containing
+file → the active file; `depth[1] === Infinity` falls back to the caller's
+own default (each type has a different one).
+
+`try_dataview_from_query` (`src/codeblocks/dataview_from.ts`) — a safe
+wrapper around `dataview_from_query` that swallows parse errors and always
+re-queries live. Markmap always did this (it depended on the external
+Dataview plugin's async-ready index before it had its own `dataview_from.ts`,
+so live-querying was never optional); Tree and Mermaid used to read a `from`
+match precomputed once at `CodeblockMDRC.onload()` time and never refreshed
+it — so a `GRAPH_UPDATE`-triggered `update()` could act on a stale match.
+Both now call `try_dataview_from_query` on every update.
+
+**`from`'s two semantics stay separate, deliberately:** Tree/Mermaid treat a
+`from` match as a *restrict-filter* — they always enter the traversal from
+`source_path`, and only use the match to bound which nodes may appear
+(`dataviewFrom`). Markmap treats a match as *replacing the entry point* — it
+walks from every matched path instead of the active file, for a
+map-of-everything-matching-this-query view. This is not drift from one
+design: Markmap's shape predates Tree/Mermaid's `from` support and has a
+different origin (the external-Dataview-plugin era). Don't unify them without
+a deliberate decision — that's a behavior change to `from`, not a refactor.
+
+**Bug the extraction surfaced and fixed:** Mermaid resolved `source_path`
+honoring `start-note`, but its traversal entry was hardcoded to
+`[file_path]` — so `start-note` never actually moved a mermaid codeblock's
+entry point. It now enters from the resolved `source_path`, like Tree and
+Markmap always have.
+
+---
+
 ## Owned WASM lifecycle (`useOwned`)
 
 `src/stores/use_owned.svelte.ts` — a rune helper that owns a derived WASM

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -83,6 +83,24 @@ now `!settings.merge_fields` everywhere.
 
 ---
 
+## Tree entry-path resolution
+
+`resolve_tree_entry_paths` (`src/graph/resolve_tree_entry_paths.ts`) — a pure
+function, sibling to `walk_to_roots`, that decides which node(s) `TreeView`
+renders from: **locked path → find-root walk → active file**, in that
+precedence, falling through when a preferred option isn't available (e.g. a
+locked path no longer in the graph, or `find_root` with no field labels
+configured).
+
+Before this seam, the precedence tree lived inline in TreeView's
+`entry_paths` `$derived.by`, fused with Svelte's reactive tracking — the
+policy (which branch wins, and the fallthrough behavior) had no test surface
+of its own; verifying it meant mounting the component. The component's
+`entry_paths` is now a one-line call; the branch logic is unit-tested
+directly (9 cases: guards, each branch, precedence, fallthroughs).
+
+---
+
 ## Owned WASM lifecycle (`useOwned`)
 
 `src/stores/use_owned.svelte.ts` — a rune helper that owns a derived WASM

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -137,6 +137,38 @@ Markmap always have.
 
 ---
 
+## Edge-field resolution: read_edge_field vs. validate_optional_edge_field
+
+`read_edge_field` (`src/graph/builders/explicit/read_edge_field.ts`) is the
+seam for a builder's *primary* field: per-note `BC-<source>-field` override,
+falling back to a settings default when the source has one
+(`EDGE_FIELD_SLOTS[source].primary`), invalid → bail the note out entirely.
+`FieldSource` now includes `traverse_note` (folded in — it had re-implemented
+the exact same shape via a direct `validate_edge_field` call).
+
+`validate_optional_edge_field` (`src/graph/builders/explicit/validate_field.ts`)
+is the seam for a builder's *secondary*, optional field (a sibling/neighbour
+field): same override-then-default merge, but unset stays unset
+(`succ(undefined)`) rather than bailing the note out — only a
+present-but-invalid value is an error. Used by `tag_note`'s `sibling_field`
+and `list_note`'s `neighbour_field`.
+
+**Not part of either seam, checked and ruled out during the 2026-07-01
+review:**
+- `date_note` — no per-note override at all; its fields (`default_field`,
+  `next_field`, `up_field`) are pure settings validation. A different
+  mechanism, not a `read_edge_field` bypass.
+- `typed_link` — scans *every* frontmatter/inline-field key against the full
+  set of registered field labels (Set membership), not a single
+  override-with-fallback. Also a different mechanism.
+- `dendron_note`/`johnny_decimal_note`'s `sibling_field` — settings-only, no
+  per-note override, no validation call. A third, simpler shape; don't route
+  it through `validate_optional_edge_field` without adding the missing
+  validation as a deliberate decision, not an incidental side effect of a
+  refactor.
+
+---
+
 ## Owned WASM lifecycle (`useOwned`)
 
 `src/stores/use_owned.svelte.ts` — a rune helper that owns a derived WASM

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "lucide-svelte": "^1.0.1",
         "luxon": "^3.7.2",
         "markmap-lib": "^0.18.12",
+        "markmap-toolbar": "^0.18.12",
         "markmap-view": "^0.18.12",
         "obsidian-typings": "^6.13.0",
         "zod": "^4.4.3",
@@ -904,6 +905,8 @@
     "markmap-html-parser": ["markmap-html-parser@0.18.11", "", { "dependencies": { "@babel/runtime": "^7.22.6", "cheerio": "1.0.0" }, "peerDependencies": { "markmap-common": "*" } }, "sha512-+kC5C4sCGntGUhGvTa5VIb5rtM75cSy/VCy3tzZoNAcn2qZGdgYvljN0WvjsOzrEzp+V6XKgwzO0u2TdzNAiOg=="],
 
     "markmap-lib": ["markmap-lib@0.18.12", "", { "dependencies": { "@babel/runtime": "^7.22.6", "@vscode/markdown-it-katex": "^1.1.0", "highlight.js": "^11.8.0", "katex": "^0.16.8", "markdown-it": "^14.1.0", "markdown-it-ins": "^4.0.0", "markdown-it-mark": "^4.0.0", "markdown-it-sub": "^2.0.0", "markdown-it-sup": "^2.0.0", "markmap-html-parser": "0.18.11", "markmap-view": "0.18.12", "prismjs": "^1.29.0", "yaml": "^2.5.1" }, "peerDependencies": { "markmap-common": "*" } }, "sha512-WCA4OT+b71jYg0e4PS/6NRKqihod5OpPsvw1jEGHQwCtqQrY/yXXCeRyuL3axOS5cMy5pV8BSl4CwKfJU1LxJg=="],
+
+    "markmap-toolbar": ["markmap-toolbar@0.18.12", "", { "dependencies": { "@babel/runtime": "^7.22.6", "@gera2ld/jsx-dom": "^2.2.2" }, "peerDependencies": { "markmap-common": "*" } }, "sha512-+MQ/95ywl/ZLhVKb0tKjRa3p/AuUSYsuJRs1MPHmkxcxBaumXgzLNHUUnLjKmsbNxeZUSQGe3QJaFyRQYcHZJg=="],
 
     "markmap-view": ["markmap-view@0.18.12", "", { "dependencies": { "@babel/runtime": "^7.22.6", "d3": "^7.8.5" }, "peerDependencies": { "markmap-common": "*" } }, "sha512-D8bzT1YwIC/8rkbwm6WzigVUrpOAGv7ioEGTi1Lj+Oo8gO5sAm6hhli27jvTgUcZ9TwBeIWZ+dSUP+AupYUGlQ=="],
 

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
 		"lucide-svelte": "^1.0.1",
 		"luxon": "^3.7.2",
 		"markmap-lib": "^0.18.12",
+		"markmap-toolbar": "^0.18.12",
 		"markmap-view": "^0.18.12",
 		"obsidian-typings": "^6.13.0",
 		"zod": "^4.4.3"

--- a/src/codeblocks/dataview_from.ts
+++ b/src/codeblocks/dataview_from.ts
@@ -161,3 +161,21 @@ export function dataview_from_query(
 		)
 		.map((file) => file.path);
 }
+
+/**
+ * Evaluate a `from` query, swallowing parse errors (invalid syntax is
+ * surfaced separately at codeblock parse-time) and re-running on every call
+ * so callers see fresh vault state rather than a value cached from load.
+ */
+export function try_dataview_from_query(
+	query: string | undefined,
+	app: App,
+	source_path: string,
+): string[] | undefined {
+	if (!query) return undefined;
+	try {
+		return dataview_from_query(query, app, source_path);
+	} catch {
+		return undefined;
+	}
+}

--- a/src/codeblocks/index.ts
+++ b/src/codeblocks/index.ts
@@ -116,13 +116,12 @@ function postprocess_options(
 	}
 
 	// `from` is the canonical field (the schema coalesces `dataview-from` into it).
+	// Only validated here -- each codeblock type live-queries it on its own
+	// update() (via try_dataview_from_query) rather than reading a value
+	// precomputed once at parse time, which could go stale.
 	if (parsed.from) {
 		try {
-			parsed["from-paths"] = dataview_from_query(
-				parsed.from,
-				plugin.app,
-				source_path,
-			);
+			dataview_from_query(parsed.from, plugin.app, source_path);
 		} catch {
 			errors.push({
 				path: "from",

--- a/src/codeblocks/resolve_codeblock_source.ts
+++ b/src/codeblocks/resolve_codeblock_source.ts
@@ -12,7 +12,7 @@ export interface ResolvedCodeblockSource {
  * to the caller's default (each type has its own).
  */
 export function resolve_codeblock_source(
-	options: { "start-note"?: string; depth: [number, number] },
+	options: { "start-note"?: string; depth: number[] },
 	file_path: string,
 	active_file_path: string | undefined,
 	default_max_depth: number,

--- a/src/codeblocks/resolve_codeblock_source.ts
+++ b/src/codeblocks/resolve_codeblock_source.ts
@@ -1,0 +1,39 @@
+import type { NoteGraph } from "wasm/pkg/breadcrumbs_graph_wasm";
+
+export interface ResolvedCodeblockSource {
+	source_path: string;
+	max_depth: number;
+}
+
+/**
+ * The source-note and max-depth arithmetic shared by all three codeblock
+ * types (Tree/Mermaid/Markmap): `start-note` override, else the codeblock's
+ * containing file, else the active file; `depth[1] === Infinity` falls back
+ * to the caller's default (each type has its own).
+ */
+export function resolve_codeblock_source(
+	options: { "start-note"?: string; depth: [number, number] },
+	file_path: string,
+	active_file_path: string | undefined,
+	default_max_depth: number,
+): ResolvedCodeblockSource {
+	const source_path =
+		options["start-note"] || file_path || active_file_path || "";
+
+	const max_depth =
+		options.depth[1] === Infinity
+			? default_max_depth
+			: (options.depth[1] ?? default_max_depth);
+
+	return { source_path, max_depth };
+}
+
+/** Error message for a resolved source_path that isn't in the graph, or undefined if valid. */
+export function validate_codeblock_entry(
+	graph: NoteGraph,
+	source_path: string,
+): string | undefined {
+	return graph.has_node(source_path)
+		? undefined
+		: "The file does not exist in the graph.";
+}

--- a/src/codeblocks/schema.ts
+++ b/src/codeblocks/schema.ts
@@ -313,7 +313,5 @@ export interface ICodeblock {
 	InputData: InputData;
 
 	/** Once resolved, the non-optional fields WILL be there, with a default if missing */
-	Options: z.infer<ReturnType<typeof build>> & {
-		"from-paths"?: string[];
-	};
+	Options: z.infer<ReturnType<typeof build>>;
 }

--- a/src/components/codeblocks/CodeblockMarkmap.svelte
+++ b/src/components/codeblocks/CodeblockMarkmap.svelte
@@ -11,13 +11,15 @@
 	import CopyToClipboardButton from "../button/CopyToClipboardButton.svelte";
 	import CodeblockErrors from "./CodeblockErrors.svelte";
 	import {
-		create_edge_sorter,
 		FlatTraversalResult,
 		NoteGraphError,
-		TraversalOptions,
-		TraversalPostprocessOptions,
 	} from "wasm/pkg/breadcrumbs_graph_wasm";
-	import { dataview_from_query } from "src/codeblocks/dataview_from";
+	import { try_dataview_from_query } from "src/codeblocks/dataview_from";
+	import {
+		resolve_codeblock_source,
+		validate_codeblock_entry,
+	} from "src/codeblocks/resolve_codeblock_source";
+	import { traverse } from "src/graph/traversal";
 	import { log } from "src/logger";
 	import { Links } from "src/utils/links";
 	import { Transformer } from "markmap-lib";
@@ -42,9 +44,6 @@
 		parent_component = undefined,
 	}: Props = $props();
 
-	let sort = $derived(
-		create_edge_sorter(options.sort.field, options.sort.order === -1),
-	);
 	let show_node_options = $derived(
 		plugin.settings.views.codeblocks.show_node_options,
 	);
@@ -58,29 +57,21 @@
 	let active_file = $derived($active_file_store);
 
 	export function update() {
-		const max_depth =
-			options.depth[1] === Infinity
-				? DEFAULT_MAX_DEPTH
-				: (options.depth[1] ?? DEFAULT_MAX_DEPTH);
+		const { source_path, max_depth } = resolve_codeblock_source(
+			options,
+			file_path,
+			active_file?.path,
+			DEFAULT_MAX_DEPTH,
+		);
 
-		const source_path =
-			options["start-note"] || file_path || active_file?.path || "";
-
-		// Re-query on every update so we pick up fresh vault state
-		// (the paths pre-computed in postprocess_options may be stale if the
-		// graph wasn't ready when the MDRC first loaded).
-		let live_dv_paths: string[] | undefined;
-		if (options.from) {
-			try {
-				live_dv_paths = dataview_from_query(
-					options.from,
-					plugin.app,
-					file_path,
-				);
-			} catch (_) {
-				// Fall through to source_path traversal
-			}
-		}
+		// Re-query on every update so we pick up fresh vault state (the
+		// paths pre-computed at parse time may be stale if the graph wasn't
+		// ready when the MDRC first loaded).
+		const live_dv_paths = try_dataview_from_query(
+			options.from,
+			plugin.app,
+			file_path,
+		);
 
 		const has_dv_paths = !!live_dv_paths?.length;
 		active_dv_paths = live_dv_paths;
@@ -94,35 +85,32 @@
 				error = "None of the `from` notes exist in the graph.";
 				return;
 			}
-		} else if (!plugin.graph.has_node(source_path)) {
-			data = undefined;
-			error = "The file does not exist in the graph.";
-			return;
+		} else {
+			const validation_error = validate_codeblock_entry(
+				plugin.graph,
+				source_path,
+			);
+			if (validation_error) {
+				data = undefined;
+				error = validation_error;
+				return;
+			}
 		}
 
 		const entry_nodes = has_dv_paths ? live_dv_paths! : [source_path];
 
-		const traversal_options = new TraversalOptions(
-			entry_nodes,
-			options.fields,
-			max_depth,
-			100, // max nodes to traverse
-			!options["merge-fields"],
-			// When `from:` is given, keep traversal within that set so the
-			// map doesn't escape into the whole vault.
-			has_dv_paths ? live_dv_paths : undefined,
-		);
-
-		const postprocess_options = new TraversalPostprocessOptions(
-			sort,
-			options.flat,
-		);
-
 		try {
-			const new_data = plugin.graph.rec_traverse_and_process(
-				traversal_options,
-				postprocess_options,
-			);
+			const new_data = traverse(plugin.graph, {
+				entry: entry_nodes,
+				fields: options.fields,
+				depth: max_depth,
+				separateEdges: !options["merge-fields"],
+				// When `from:` is given, keep traversal within that set so
+				// the map doesn't escape into the whole vault.
+				dataviewFrom: has_dv_paths ? live_dv_paths : undefined,
+				sort: options.sort,
+				flatten: options.flat,
+			});
 			const old_data = data;
 			data = new_data; // update state before freeing so derivations read valid data
 			old_data?.free();

--- a/src/components/codeblocks/CodeblockMarkmap.svelte
+++ b/src/components/codeblocks/CodeblockMarkmap.svelte
@@ -24,6 +24,7 @@
 	import { Links } from "src/utils/links";
 	import { Transformer } from "markmap-lib";
 	import { Markmap, globalCSS, loadCSS } from "markmap-view";
+	import { Toolbar } from "markmap-toolbar";
 
 	// Inject markmap styles into the document once.
 	loadCSS([{ type: "style", data: globalCSS }]);
@@ -178,6 +179,7 @@
 
 	// Markmap SVG rendering
 	let svg_el: SVGElement | undefined = $state(undefined);
+	let toolbar_el: HTMLDivElement | undefined = $state(undefined);
 	let mm: Markmap | undefined;
 	const transformer = new Transformer();
 
@@ -235,6 +237,14 @@
 			mm = Markmap.create(svg_el, undefined, root);
 			svg_el.addEventListener("click", handle_node_click);
 			void mm.fit();
+
+			const toolbar = Toolbar.create(mm);
+			toolbar.showBrand = false;
+			// "dark" duplicates Obsidian's own theme toggle -- drop it.
+			toolbar.setItems(
+				toolbar.items.filter((item) => item !== "dark"),
+			);
+			toolbar_el?.appendChild(toolbar.el);
 		}
 	});
 
@@ -266,6 +276,11 @@
 					cls="clickable-icon nav-action-button"
 				/>
 			</div>
+			<div
+				bind:this={toolbar_el}
+				class="absolute bottom-2 right-2"
+				style="z-index: 1;"
+			></div>
 			<svg
 				bind:this={svg_el}
 				style="width: 100%; height: 400px; display: block;"

--- a/src/components/codeblocks/CodeblockMarkmap.svelte
+++ b/src/components/codeblocks/CodeblockMarkmap.svelte
@@ -278,8 +278,8 @@
 			</div>
 			<div
 				bind:this={toolbar_el}
-				class="absolute bottom-2 right-2"
-				style="z-index: 1;"
+				class="absolute"
+				style="z-index: 1; bottom: 0.5rem; right: 0.5rem;"
 			></div>
 			<svg
 				bind:this={svg_el}

--- a/src/components/codeblocks/CodeblockMermaid.svelte
+++ b/src/components/codeblocks/CodeblockMermaid.svelte
@@ -17,6 +17,11 @@
 		create_edge_sorter,
 	} from "wasm/pkg/breadcrumbs_graph_wasm";
 	import { build_traversal_options } from "src/graph/traversal";
+	import {
+		resolve_codeblock_source,
+		validate_codeblock_entry,
+	} from "src/codeblocks/resolve_codeblock_source";
+	import { try_dataview_from_query } from "src/codeblocks/dataview_from";
 	import { remove_nullish_keys } from "src/utils/objects";
 	import { Paths } from "src/utils/paths";
 	import { Links } from "src/utils/links";
@@ -39,26 +44,32 @@
 	let active_file = $derived($active_file_store);
 
 	export function update() {
-		const max_depth =
-			options.depth[1] === Infinity
-				? DEFAULT_MAX_DEPTH
-				: (options.depth[1] ?? DEFAULT_MAX_DEPTH);
+		const { source_path, max_depth } = resolve_codeblock_source(
+			options,
+			file_path,
+			active_file?.path,
+			DEFAULT_MAX_DEPTH,
+		);
 
-		const source_path =
-			options["start-note"] || file_path || active_file?.path || "";
-
-		if (!plugin.graph.has_node(source_path)) {
+		const validation_error = validate_codeblock_entry(
+			plugin.graph,
+			source_path,
+		);
+		if (validation_error) {
 			code = "";
-			error = "The file does not exist in the graph.";
+			error = validation_error;
 			return;
 		}
 
-		const entry_nodes = [file_path];
-		// Restricts which nodes a traversal may include (None = unrestricted).
-		const allowed_paths = options["from-paths"];
+		// Restricts which nodes a traversal may include (undefined = unrestricted).
+		const allowed_paths = try_dataview_from_query(
+			options.from,
+			plugin.app,
+			file_path,
+		);
 
 		const traversal_options = build_traversal_options({
-			entry: entry_nodes,
+			entry: [source_path],
 			fields: options.fields,
 			depth: max_depth,
 			separateEdges: !options["merge-fields"],

--- a/src/components/codeblocks/CodeblockTree.svelte
+++ b/src/components/codeblocks/CodeblockTree.svelte
@@ -12,6 +12,11 @@
 		NoteGraphError,
 	} from "wasm/pkg/breadcrumbs_graph_wasm";
 	import { traverse } from "src/graph/traversal";
+	import {
+		resolve_codeblock_source,
+		validate_codeblock_entry,
+	} from "src/codeblocks/resolve_codeblock_source";
+	import { try_dataview_from_query } from "src/codeblocks/dataview_from";
 	import NestedEdgeList from "../NestedEdgeList.svelte";
 	import CopyToClipboardButton from "../button/CopyToClipboardButton.svelte";
 	import CodeblockErrors from "./CodeblockErrors.svelte";
@@ -43,19 +48,28 @@
 	let active_file = $derived($active_file_store);
 
 	export function update() {
-		const max_depth =
-			options.depth[1] === Infinity
-				? DEFAULT_MAX_DEPTH
-				: (options.depth[1] ?? DEFAULT_MAX_DEPTH);
+		const { source_path, max_depth } = resolve_codeblock_source(
+			options,
+			file_path,
+			active_file?.path,
+			DEFAULT_MAX_DEPTH,
+		);
 
-		const source_path =
-			options["start-note"] || file_path || active_file?.path || "";
-
-		if (!plugin.graph.has_node(source_path)) {
+		const validation_error = validate_codeblock_entry(
+			plugin.graph,
+			source_path,
+		);
+		if (validation_error) {
 			data = undefined;
-			error = "The file does not exist in the graph.";
+			error = validation_error;
 			return;
 		}
+
+		const dv_paths = try_dataview_from_query(
+			options.from,
+			plugin.app,
+			file_path,
+		);
 
 		try {
 			const new_data = traverse(plugin.graph, {
@@ -63,12 +77,13 @@
 				fields: options.fields,
 				depth: max_depth,
 				separateEdges: !options["merge-fields"],
-				dataviewFrom: options["from-paths"],
+				dataviewFrom: dv_paths,
 				sort: options.sort,
 				flatten: options.flat,
 			});
-			data?.free(); // free previous FlatTraversalResult
-			data = new_data;
+			const old_data = data;
+			data = new_data; // assign before freeing so derivations never read a freed handle
+			old_data?.free();
 			error = undefined;
 		} catch (e) {
 			log.error("Error updating codeblock tree", e);

--- a/src/components/side_views/TreeView.svelte
+++ b/src/components/side_views/TreeView.svelte
@@ -23,7 +23,7 @@
 	import { prepareFuzzySearch } from "obsidian";
 	import { effect_counter } from "src/utils/perf";
 	import { to_node_stringify_options } from "src/graph/utils";
-	import { walk_to_roots } from "src/graph/walk_to_roots";
+	import { resolve_tree_entry_paths } from "src/graph/resolve_tree_entry_paths";
 	import { log } from "src/logger";
 	import { useViewSettings } from "src/stores/use_view_settings.svelte";
 	import SearchToggleButton from "../button/SearchToggleButton.svelte";
@@ -75,23 +75,14 @@
 		depth = settings.default_depth;
 	});
 
-	let entry_paths = $derived.by(() => {
-		if (!active_file || !plugin.graph.has_node(active_file.path))
-			return undefined;
-		if (settings.lock_view && plugin.graph.has_node(settings.lock_path!)) {
-			log.debug("Using locked path for TreeView:", settings.lock_path);
-			return [settings.lock_path!];
-		} else if (settings.find_root && find_root_field_labels.length > 0) {
-			const roots = walk_to_roots(
-				plugin.graph,
-				active_file.path,
-				find_root_field_labels,
-			);
-			log.debug("find_root: walked up to roots", roots);
-			return roots;
-		}
-		return [active_file.path];
-	});
+	let entry_paths = $derived(
+		resolve_tree_entry_paths(plugin.graph, active_file?.path, {
+			lock_view: settings.lock_view,
+			lock_path: settings.lock_path,
+			find_root: settings.find_root,
+			find_root_field_labels,
+		}),
+	);
 
 	let entry_path = $derived(
 		entry_paths?.length === 1 ? entry_paths[0] : undefined,

--- a/src/graph/builders/explicit/list_note.ts
+++ b/src/graph/builders/explicit/list_note.ts
@@ -9,7 +9,7 @@ import { resolve_relative_target_path } from "src/utils/obsidian";
 import { fail, graph_build_fail, succ } from "src/utils/result";
 import { GCEdgeData, GCNodeData } from "wasm/pkg/breadcrumbs_graph_wasm";
 import { read_edge_field } from "./read_edge_field";
-import { validate_edge_field } from "./validate_field";
+import { validate_optional_edge_field } from "./validate_field";
 
 interface NativeListItem {
 	position: { start: { line: number; col: number } };
@@ -117,19 +117,17 @@ const get_list_note_info = (
 	if (!field_res.ok) return field_res;
 	const field = field_res.data;
 
-	const neighbour_field =
+	const raw_neighbour_field =
 		metadata[META_ALIAS["list-note-neighbour-field"]] ??
 		plugin.settings.explicit_edge_sources.list_note.default_neighbour_field;
 
-	if (neighbour_field) {
-		const neighbour_res = validate_edge_field(
-			plugin,
-			neighbour_field,
-			path,
-			"list-note-neighbour-field",
-		);
-		if (!neighbour_res.ok) return neighbour_res;
-	}
+	const neighbour_res = validate_optional_edge_field(
+		plugin,
+		raw_neighbour_field,
+		path,
+		"list-note-neighbour-field",
+	);
+	if (!neighbour_res.ok) return neighbour_res;
 
 	// list-note-exclude-index ignores out-edges, but _only for list-notes_
 	const exclude_index = Boolean(
@@ -144,7 +142,7 @@ const get_list_note_info = (
 		field,
 		exclude_index,
 		section,
-		neighbour_field: (neighbour_field ?? undefined) as string | undefined,
+		neighbour_field: neighbour_res.data,
 	});
 };
 

--- a/src/graph/builders/explicit/read_edge_field.ts
+++ b/src/graph/builders/explicit/read_edge_field.ts
@@ -17,7 +17,8 @@ export type FieldSource =
 	| "regex_note"
 	| "dataview_note"
 	| "folder_note"
-	| "list_note";
+	| "list_note"
+	| "traverse_note";
 
 interface EdgeFieldSourceConfig {
 	/** The `BC-…-field` key — both the frontmatter override and the error label. */
@@ -26,7 +27,8 @@ interface EdgeFieldSourceConfig {
 
 // The builder default (when the per-note override is absent) comes from
 // EDGE_FIELD_SLOTS[source].primary, shared with the rename/remove cascade.
-// folder_note and list_note have no primary slot there → required, no default.
+// folder_note, list_note, and traverse_note have no primary slot there →
+// required, no default.
 const EDGE_FIELD_SOURCES: Record<FieldSource, EdgeFieldSourceConfig> = {
 	tag_note: { alias_key: "tag-note-field" },
 	dendron_note: { alias_key: "dendron-note-field" },
@@ -35,6 +37,7 @@ const EDGE_FIELD_SOURCES: Record<FieldSource, EdgeFieldSourceConfig> = {
 	dataview_note: { alias_key: "dataview-note-field" },
 	folder_note: { alias_key: "folder-note-field" },
 	list_note: { alias_key: "list-note-field" },
+	traverse_note: { alias_key: "traverse-note-field" },
 };
 
 /**

--- a/src/graph/builders/explicit/tag_note.ts
+++ b/src/graph/builders/explicit/tag_note.ts
@@ -9,7 +9,7 @@ import { fail, graph_build_fail, succ } from "src/utils/result";
 import { ensure_starts_with } from "src/utils/strings";
 import { GCEdgeData } from "wasm/pkg/breadcrumbs_graph_wasm";
 import { read_edge_field } from "./read_edge_field";
-import { validate_edge_field } from "./validate_field";
+import { validate_optional_edge_field } from "./validate_field";
 
 const parse_frontmatter_tags = (
 	frontmatter: Record<string, unknown> | undefined,
@@ -61,19 +61,15 @@ const get_tag_note_info = (
 		metadata[META_ALIAS["tag-note-sibling-field"]] ??
 		plugin.settings.explicit_edge_sources.tag_note.default_sibling_field;
 
-	let sibling_field: string | undefined;
-	if (raw_sibling_field) {
-		const sibling_res = validate_edge_field(
-			plugin,
-			raw_sibling_field,
-			path,
-			"tag-note-sibling-field",
-		);
-		if (!sibling_res.ok) return sibling_res;
-		sibling_field = sibling_res.data;
-	}
+	const sibling_res = validate_optional_edge_field(
+		plugin,
+		raw_sibling_field,
+		path,
+		"tag-note-sibling-field",
+	);
+	if (!sibling_res.ok) return sibling_res;
 
-	return succ({ tag, field, exact, sibling_field });
+	return succ({ tag, field, exact, sibling_field: sibling_res.data });
 };
 
 /**

--- a/src/graph/builders/explicit/traverse_note.ts
+++ b/src/graph/builders/explicit/traverse_note.ts
@@ -1,11 +1,9 @@
-import { META_ALIAS } from "src/const/metadata_fields";
 import type {
 	EdgeBuilderResults,
 	ExplicitEdgeBuilder,
 } from "src/interfaces/graph";
-import { fail, succ } from "src/utils/result";
 import { GCEdgeData } from "wasm/pkg/breadcrumbs_graph_wasm";
-import { validate_edge_field } from "./validate_field";
+import { read_edge_field } from "./read_edge_field";
 
 /**
  * Walk the Obsidian vault link graph from a starting note using iterative DFS.
@@ -36,24 +34,6 @@ function dfs_edges(
 	return edges;
 }
 
-const get_traverse_note_field = (
-	plugin: Parameters<ExplicitEdgeBuilder>[0],
-	metadata: Record<string, unknown> | undefined,
-	path: string,
-) => {
-	if (!metadata) return fail(undefined);
-
-	const field_res = validate_edge_field(
-		plugin,
-		metadata[META_ALIAS["traverse-note-field"]],
-		path,
-		"traverse-note-field",
-	);
-	if (!field_res.ok) return field_res;
-
-	return succ(field_res.data);
-};
-
 /**
  * **traverse_note** — vault-link DFS edge builder.
  *
@@ -75,8 +55,9 @@ export const _add_explicit_edges_traverse_note: ExplicitEdgeBuilder = (
 	const resolved_links = plugin.app.metadataCache.resolvedLinks;
 
 	all_files.obsidian.forEach(({ file, cache }) => {
-		const field_result = get_traverse_note_field(
+		const field_result = read_edge_field(
 			plugin,
+			"traverse_note",
 			cache?.frontmatter,
 			file.path,
 		);

--- a/src/graph/builders/explicit/validate_field.ts
+++ b/src/graph/builders/explicit/validate_field.ts
@@ -40,3 +40,24 @@ export const validate_edge_field = (
 
 	return succ(field);
 };
+
+/**
+ * Validate an *optional* secondary edge-field (e.g. a sibling/neighbour
+ * field): the caller has already merged the per-note override with its
+ * settings default. Unset stays unset (`succ(undefined)`, not `fail`) so the
+ * caller can continue building the note rather than bailing out — only a
+ * present-but-invalid value is an error.
+ */
+export const validate_optional_edge_field = (
+	plugin: BreadcrumbsPlugin,
+	field: unknown,
+	path: string,
+	field_name: string,
+): Result<string | undefined, BreadcrumbsError> => {
+	if (!field) return succ(undefined);
+
+	const res = validate_edge_field(plugin, field, path, field_name);
+	// `field` is truthy here, so validate_edge_field can't take its
+	// fail(undefined) branch -- error is always a real BreadcrumbsError.
+	return res.ok ? succ(res.data) : { ok: false, error: res.error! };
+};

--- a/src/graph/resolve_tree_entry_paths.ts
+++ b/src/graph/resolve_tree_entry_paths.ts
@@ -1,0 +1,34 @@
+import type { NoteGraph } from "wasm/pkg/breadcrumbs_graph_wasm";
+import { walk_to_roots } from "./walk_to_roots";
+
+/**
+ * Decide which node(s) a tree side-view should start rendering from:
+ * a locked path, the find-root walk, or the active file itself — in that
+ * precedence order, falling through when a preferred option isn't available.
+ */
+export function resolve_tree_entry_paths(
+	graph: NoteGraph,
+	active_file_path: string | undefined,
+	options: {
+		lock_view: boolean;
+		lock_path: string;
+		find_root: boolean;
+		find_root_field_labels: string[];
+	},
+): string[] | undefined {
+	if (!active_file_path || !graph.has_node(active_file_path)) return undefined;
+
+	if (options.lock_view && graph.has_node(options.lock_path)) {
+		return [options.lock_path];
+	}
+
+	if (options.find_root && options.find_root_field_labels.length > 0) {
+		return walk_to_roots(
+			graph,
+			active_file_path,
+			options.find_root_field_labels,
+		);
+	}
+
+	return [active_file_path];
+}

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -30,6 +30,25 @@ export class TFolder extends TAbstractFile {
 	}
 }
 
+/** Matches real Obsidian closely enough for dataview_from's `#tag` atom: body
+ *  tags plus frontmatter `tags` (string or array), each normalised to `#`. */
+export function getAllTags(cache: {
+	tags?: { tag: string }[];
+	frontmatter?: Record<string, unknown>;
+}): string[] | null {
+	const tags: string[] = cache.tags?.map((t) => t.tag) ?? [];
+
+	const fm_tags = cache.frontmatter?.tags;
+	const raw = typeof fm_tags === "string" ? [fm_tags] : (fm_tags ?? []);
+	if (Array.isArray(raw)) {
+		for (const t of raw) {
+			if (typeof t === "string") tags.push(t.startsWith("#") ? t : `#${t}`);
+		}
+	}
+
+	return tags.length ? tags : null;
+}
+
 export class Plugin {}
 export class PluginSettingTab {}
 export class Modal {}

--- a/tests/codeblocks/dataview_from.test.ts
+++ b/tests/codeblocks/dataview_from.test.ts
@@ -1,0 +1,266 @@
+import {
+	dataview_from_query,
+	try_dataview_from_query,
+} from "src/codeblocks/dataview_from";
+import { describe, expect, test } from "vitest";
+import type { App } from "obsidian";
+import { TFile, TFolder } from "obsidian";
+
+/** Build a minimal file with an optional tag/frontmatter cache. */
+function mock_file(
+	path: string,
+	opts: { tags?: string[]; frontmatter_tags?: string | string[] } = {},
+) {
+	const parts = path.split("/");
+	const name = parts[parts.length - 1];
+	const dot = name.lastIndexOf(".");
+
+	const file = Object.assign(new TFile(), {
+		path,
+		name,
+		basename: dot > -1 ? name.slice(0, dot) : name,
+		extension: dot > -1 ? name.slice(dot + 1) : "",
+		parent: Object.assign(new TFolder(), {
+			path: parts.slice(0, -1).join("/"),
+		}),
+	});
+
+	const cache =
+		opts.tags || opts.frontmatter_tags
+			? {
+					tags: opts.tags?.map((tag) => ({ tag })),
+					frontmatter: opts.frontmatter_tags
+						? { tags: opts.frontmatter_tags }
+						: undefined,
+				}
+			: null;
+
+	return { file, cache };
+}
+
+/** Build a minimal App: a vault of files, plus link resolution for [[link]]. */
+function mock_app(
+	files: ReturnType<typeof mock_file>[],
+	opts: {
+		/** link text -> resolved TFile, for getFirstLinkpathDest */
+		resolve?: Record<string, TFile>;
+		/** source path -> set of target paths it resolves to (outlinks) */
+		resolved_links?: Record<string, string[]>;
+	} = {},
+): App {
+	const by_path = new Map(files.map((f) => [f.file.path, f]));
+
+	return {
+		vault: {
+			getFiles: () => files.map((f) => f.file),
+		},
+		metadataCache: {
+			getFileCache: (file: TFile) => by_path.get(file.path)?.cache ?? null,
+			getFirstLinkpathDest: (link_text: string) =>
+				opts.resolve?.[link_text] ?? null,
+			resolvedLinks: Object.fromEntries(
+				Object.entries(opts.resolved_links ?? {}).map(
+					([source, targets]) => [
+						source,
+						Object.fromEntries(targets.map((t) => [t, 1])),
+					],
+				),
+			),
+		},
+	} as unknown as App;
+}
+
+describe("dataview_from_query", () => {
+	test("#tag matches a file with that exact tag", () => {
+		const a = mock_file("a.md", { tags: ["#project"] });
+		const b = mock_file("b.md", { tags: ["#other"] });
+		const app = mock_app([a, b]);
+
+		expect(dataview_from_query("#project", app, "src.md")).toEqual([
+			"a.md",
+		]);
+	});
+
+	test("#tag matches sub-tags (#project matches #project/sub)", () => {
+		const a = mock_file("a.md", { tags: ["#project/sub"] });
+		const app = mock_app([a]);
+
+		expect(dataview_from_query("#project", app, "src.md")).toEqual([
+			"a.md",
+		]);
+	});
+
+	test("#tag does not match a different parent tag", () => {
+		const a = mock_file("a.md", { tags: ["#projectx"] });
+		const app = mock_app([a]);
+
+		expect(dataview_from_query("#project", app, "src.md")).toEqual([]);
+	});
+
+	test("#tag reads frontmatter tags (string form)", () => {
+		const a = mock_file("a.md", { frontmatter_tags: "project" });
+		const app = mock_app([a]);
+
+		expect(dataview_from_query("#project", app, "src.md")).toEqual([
+			"a.md",
+		]);
+	});
+
+	test("#tag reads frontmatter tags (array form)", () => {
+		const a = mock_file("a.md", { frontmatter_tags: ["other", "project"] });
+		const app = mock_app([a]);
+
+		expect(dataview_from_query("#project", app, "src.md")).toEqual([
+			"a.md",
+		]);
+	});
+
+	test('"folder" matches files in that folder and its subfolders', () => {
+		const a = mock_file("Projects/a.md");
+		const b = mock_file("Projects/Sub/b.md");
+		const c = mock_file("Other/c.md");
+		const app = mock_app([a, b, c]);
+
+		expect(
+			dataview_from_query('"Projects"', app, "src.md").sort(),
+		).toEqual(["Projects/Sub/b.md", "Projects/a.md"]);
+	});
+
+	test('"folder" is case-insensitive', () => {
+		const a = mock_file("Projects/a.md");
+		const app = mock_app([a]);
+
+		expect(dataview_from_query('"projects"', app, "src.md")).toEqual([
+			"Projects/a.md",
+		]);
+	});
+
+	test('"" (empty folder) matches every file', () => {
+		const a = mock_file("a.md");
+		const b = mock_file("Projects/b.md");
+		const app = mock_app([a, b]);
+
+		expect(dataview_from_query('""', app, "src.md").sort()).toEqual([
+			"Projects/b.md",
+			"a.md",
+		]);
+	});
+
+	test("[[link]] matches files that resolve a link to the target", () => {
+		const target = Object.assign(new TFile(), {
+			path: "Target.md",
+			basename: "Target",
+		});
+		const a = mock_file("a.md");
+		const b = mock_file("b.md");
+		const app = mock_app([a, b], {
+			resolve: { Target: target },
+			resolved_links: { "a.md": ["Target.md"] },
+		});
+
+		expect(dataview_from_query("[[Target]]", app, "src.md")).toEqual([
+			"a.md",
+		]);
+	});
+
+	test("[[link]] with an unresolved target matches nothing", () => {
+		const a = mock_file("a.md");
+		const app = mock_app([a]);
+
+		expect(dataview_from_query("[[Missing]]", app, "src.md")).toEqual([]);
+	});
+
+	test("AND requires both sides", () => {
+		const a = mock_file("a.md", { tags: ["#x", "#y"] });
+		const b = mock_file("b.md", { tags: ["#x"] });
+		const app = mock_app([a, b]);
+
+		expect(dataview_from_query("#x AND #y", app, "src.md")).toEqual([
+			"a.md",
+		]);
+	});
+
+	test("OR matches either side", () => {
+		const a = mock_file("a.md", { tags: ["#x"] });
+		const b = mock_file("b.md", { tags: ["#y"] });
+		const c = mock_file("c.md", { tags: ["#z"] });
+		const app = mock_app([a, b, c]);
+
+		expect(
+			dataview_from_query("#x OR #y", app, "src.md").sort(),
+		).toEqual(["a.md", "b.md"]);
+	});
+
+	test("NOT negates the following atom", () => {
+		const a = mock_file("a.md", { tags: ["#x"] });
+		const b = mock_file("b.md", { tags: ["#y"] });
+		const app = mock_app([a, b]);
+
+		expect(dataview_from_query("NOT #x", app, "src.md")).toEqual([
+			"b.md",
+		]);
+	});
+
+	test("AND binds tighter than OR: #x OR #y AND #z == #x OR (#y AND #z)", () => {
+		const a = mock_file("a.md", { tags: ["#x"] });
+		const b = mock_file("b.md", { tags: ["#y"] }); // y without z: shouldn't match
+		const c = mock_file("c.md", { tags: ["#y", "#z"] });
+		const app = mock_app([a, b, c]);
+
+		expect(
+			dataview_from_query("#x OR #y AND #z", app, "src.md").sort(),
+		).toEqual(["a.md", "c.md"]);
+	});
+
+	test("parens override default precedence", () => {
+		const a = mock_file("a.md", { tags: ["#x"] });
+		const b = mock_file("b.md", { tags: ["#y"] });
+		const c = mock_file("c.md", { tags: ["#z"] });
+		const app = mock_app([a, b, c]);
+
+		// (#x OR #y) AND #z -- none of these files satisfy it, unlike the
+		// unparenthesised #x OR (#y AND #z) case above.
+		expect(
+			dataview_from_query("(#x OR #y) AND #z", app, "src.md"),
+		).toEqual([]);
+	});
+
+	test("an unrecognised atom matches nothing, without throwing", () => {
+		const a = mock_file("a.md", { tags: ["#x"] });
+		const app = mock_app([a]);
+
+		expect(() =>
+			dataview_from_query("garbage!!!", app, "src.md"),
+		).not.toThrow();
+		expect(dataview_from_query("garbage!!!", app, "src.md")).toEqual([]);
+	});
+
+	test("only md/canvas/base extensions are candidates", () => {
+		const md = mock_file("a.md");
+		const png = mock_file("b.png");
+		const app = mock_app([md, png]);
+
+		expect(dataview_from_query('""', app, "src.md")).toEqual(["a.md"]);
+	});
+});
+
+describe("try_dataview_from_query", () => {
+	test("undefined query -> undefined", () => {
+		const app = mock_app([]);
+		expect(try_dataview_from_query(undefined, app, "src.md")).toBeUndefined();
+	});
+
+	test("empty-string query -> undefined", () => {
+		const app = mock_app([]);
+		expect(try_dataview_from_query("", app, "src.md")).toBeUndefined();
+	});
+
+	test("a real query delegates to dataview_from_query", () => {
+		const a = mock_file("a.md", { tags: ["#x"] });
+		const app = mock_app([a]);
+
+		expect(try_dataview_from_query("#x", app, "src.md")).toEqual([
+			"a.md",
+		]);
+	});
+});

--- a/tests/codeblocks/resolve_codeblock_source.test.ts
+++ b/tests/codeblocks/resolve_codeblock_source.test.ts
@@ -1,0 +1,86 @@
+import {
+	resolve_codeblock_source,
+	validate_codeblock_entry,
+} from "src/codeblocks/resolve_codeblock_source";
+import { beforeEach, describe, expect, test } from "vitest";
+import init, {
+	create_graph,
+	GCNodeData,
+	NoteGraph,
+} from "wasm/pkg/breadcrumbs_graph_wasm";
+import fs from "node:fs/promises";
+
+beforeEach(async () => {
+	const wasmSource = await fs.readFile(
+		"wasm/pkg/breadcrumbs_graph_wasm_bg.wasm",
+	);
+	// @ts-ignore TS2345
+	const wasmModule = await WebAssembly.compile(wasmSource);
+	await init(wasmModule);
+});
+
+function graph_of(paths: string[]): NoteGraph {
+	const nodes = paths.map((p) => new GCNodeData(p, [], true, false, false));
+	const graph = create_graph();
+	graph.build_graph(nodes, [], []);
+	return graph;
+}
+
+describe("resolve_codeblock_source", () => {
+	test("start-note override wins over file_path and active_file", () => {
+		expect(
+			resolve_codeblock_source(
+				{ "start-note": "a", depth: [0, 3] },
+				"b",
+				"c",
+				5,
+			).source_path,
+		).toBe("a");
+	});
+
+	test("falls back to file_path when no start-note", () => {
+		expect(
+			resolve_codeblock_source({ depth: [0, 3] }, "b", "c", 5)
+				.source_path,
+		).toBe("b");
+	});
+
+	test("falls back to active_file when no start-note or file_path", () => {
+		expect(
+			resolve_codeblock_source({ depth: [0, 3] }, "", "c", 5)
+				.source_path,
+		).toBe("c");
+	});
+
+	test("depth[1] finite → used as max_depth", () => {
+		expect(
+			resolve_codeblock_source({ depth: [0, 3] }, "b", undefined, 5)
+				.max_depth,
+		).toBe(3);
+	});
+
+	test("depth[1] === Infinity → falls back to the caller's default", () => {
+		expect(
+			resolve_codeblock_source(
+				{ depth: [0, Infinity] },
+				"b",
+				undefined,
+				5,
+			).max_depth,
+		).toBe(5);
+	});
+});
+
+describe("validate_codeblock_entry", () => {
+	test("node in graph → no error", () => {
+		const graph = graph_of(["a"]);
+		expect(validate_codeblock_entry(graph, "a")).toBeUndefined();
+	});
+
+	test("node not in graph → error message", () => {
+		const graph = graph_of(["a"]);
+		expect(validate_codeblock_entry(graph, "missing")).toBe(
+			"The file does not exist in the graph.",
+		);
+	});
+});

--- a/tests/graph/resolve_tree_entry_paths.test.ts
+++ b/tests/graph/resolve_tree_entry_paths.test.ts
@@ -1,0 +1,145 @@
+import { resolve_tree_entry_paths } from "src/graph/resolve_tree_entry_paths";
+import { beforeEach, describe, expect, test } from "vitest";
+import init, {
+	create_graph,
+	GCEdgeData,
+	GCNodeData,
+	NoteGraph,
+} from "wasm/pkg/breadcrumbs_graph_wasm";
+import fs from "node:fs/promises";
+
+beforeEach(async () => {
+	const wasmSource = await fs.readFile(
+		"wasm/pkg/breadcrumbs_graph_wasm_bg.wasm",
+	);
+	// @ts-ignore TS2345
+	const wasmModule = await WebAssembly.compile(wasmSource);
+	await init(wasmModule);
+});
+
+/** Build a graph from `[from, to, field?]` edge tuples (field defaults to "up"). */
+function graph_of(edges: [string, string, string?][]): NoteGraph {
+	const paths = new Set<string>();
+	for (const [from, to] of edges) {
+		paths.add(from);
+		paths.add(to);
+	}
+
+	const nodes = [...paths].map(
+		(p) => new GCNodeData(p, [], true, false, false),
+	);
+	const gc_edges = edges.map(
+		([from, to, field]) => new GCEdgeData(from, to, field ?? "up", ""),
+	);
+
+	const graph = create_graph();
+	graph.build_graph(nodes, gc_edges, []);
+	return graph;
+}
+
+const no_lock_no_find_root = {
+	lock_view: false,
+	lock_path: "",
+	find_root: false,
+	find_root_field_labels: [],
+};
+
+describe("resolve_tree_entry_paths", () => {
+	test("no active file → undefined", () => {
+		const graph = graph_of([["a", "b"]]);
+		expect(
+			resolve_tree_entry_paths(graph, undefined, no_lock_no_find_root),
+		).toBeUndefined();
+	});
+
+	test("active file not in graph → undefined", () => {
+		const graph = graph_of([["a", "b"]]);
+		expect(
+			resolve_tree_entry_paths(graph, "missing", no_lock_no_find_root),
+		).toBeUndefined();
+	});
+
+	test("no lock, no find_root → the active file itself", () => {
+		const graph = graph_of([["a", "b"]]);
+		expect(
+			resolve_tree_entry_paths(graph, "a", no_lock_no_find_root),
+		).toEqual(["a"]);
+	});
+
+	test("lock_view with a valid lock_path → the locked path, ignoring active file", () => {
+		const graph = graph_of([["a", "b"]]);
+		expect(
+			resolve_tree_entry_paths(graph, "a", {
+				...no_lock_no_find_root,
+				lock_view: true,
+				lock_path: "b",
+			}),
+		).toEqual(["b"]);
+	});
+
+	test("lock_view with an invalid lock_path → falls through to find_root", () => {
+		const graph = graph_of([["a", "b"]]);
+		expect(
+			resolve_tree_entry_paths(graph, "a", {
+				lock_view: true,
+				lock_path: "missing",
+				find_root: true,
+				find_root_field_labels: ["up"],
+			}),
+		).toEqual(["b"]);
+	});
+
+	test("lock_view with an invalid lock_path and find_root off → falls through to the active file", () => {
+		const graph = graph_of([["a", "b"]]);
+		expect(
+			resolve_tree_entry_paths(graph, "a", {
+				lock_view: true,
+				lock_path: "missing",
+				find_root: false,
+				find_root_field_labels: [],
+			}),
+		).toEqual(["a"]);
+	});
+
+	test("find_root with labels → walks up to roots", () => {
+		const graph = graph_of([
+			["a", "b"],
+			["b", "c"],
+		]);
+		expect(
+			resolve_tree_entry_paths(graph, "a", {
+				lock_view: false,
+				lock_path: "",
+				find_root: true,
+				find_root_field_labels: ["up"],
+			}),
+		).toEqual(["c"]);
+	});
+
+	test("find_root true but no field labels → falls through to the active file", () => {
+		const graph = graph_of([["a", "b"]]);
+		expect(
+			resolve_tree_entry_paths(graph, "a", {
+				lock_view: false,
+				lock_path: "",
+				find_root: true,
+				find_root_field_labels: [],
+			}),
+		).toEqual(["a"]);
+	});
+
+	test("lock_view and find_root both configured and valid → lock wins", () => {
+		const graph = graph_of([
+			["a", "b"],
+			["b", "c"],
+		]);
+		expect(
+			resolve_tree_entry_paths(graph, "a", {
+				lock_view: true,
+				lock_path: "b",
+				find_root: true,
+				find_root_field_labels: ["up"],
+			}),
+		).toEqual(["b"]);
+	});
+});


### PR DESCRIPTION
## Summary
Follow-up to the 2026-06-24 architecture review (#719). Four candidates from a fresh `/improve-codebase-architecture` pass on main:

- Extract `resolve_tree_entry_paths` — pulls TreeView's lock/find_root/active_file precedence logic out, sibling to `walk_to_roots`.
- Add shared `resolve_codeblock_source` + `try_dataview_from_query`, used by Tree/Mermaid/Markmap. Fixes two real bugs found along the way: Mermaid's `start-note` never worked (entered traversal from a hardcoded path instead of the validated `source_path`), and Tree/Mermaid's `from-paths` could go stale after a `GRAPH_UPDATE` (now live-queried like Markmap already did). Markmap also migrated onto the `traverse()` facade.
- Fold `traverse_note` into `read_edge_field`'s `FieldSource` union (genuine duplicate); extract `validate_optional_edge_field` for `tag_note`'s `sibling_field` / `list_note`'s `neighbour_field` duplication. `date_note`/`typed_link`/dendron/johnny-decimal sibling fields were checked and ruled out as different mechanisms — documented in CONTEXT.md.
- `dataview_from_query` parser/eval split — evaluated and **not done** by design (single real consumer, no second adapter to justify an AST split); added test coverage instead (previously zero).

Bonus: markmap-toolbar (zoom/fit/recurse controls) added to Markmap codeblocks, with a positioning fix.

## Test plan
- [x] `bun run build` — type-check, svelte-check, esbuild all pass
- [x] `bun run test` — 360 tests passing
- [ ] Manual smoke test of Tree/Mermaid/Markmap codeblocks with `from`/`start-note` in the demo vault