### PR TITLE
fix(typed_link): allow Dataview paren/bracket wrappers in inline fields (1.12-compat)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## 4.X
 
+### [4.14.3-beta.1](https://github.com/michaelpporter/breadcrumbs/compare/4.14.2...4.14.3-beta.1) (2026-07-05)
+
+### Bug Fixes
+
+* **typed_link (1.12-compat)** — inline Dataview properties wrapped in parentheses or brackets (e.g. `(down:: [[Note]])`, `[down:: [[Note]]]`) are recognized again. Backport of the 4.15.1 fix for users still on Obsidian < 1.13 (#724).
+
 ### [4.14.2](https://github.com/michaelpporter/breadcrumbs/compare/4.14.1...4.14.2) (2026-06-05)
 
 Internal maintenance release — no user-facing behavior changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## 4.X
 
+### [4.14.3-beta.2](https://github.com/michaelpporter/breadcrumbs/compare/4.14.3-beta.1...4.14.3-beta.2) (2026-07-06)
+
+### Bug Fixes
+
+* **typed_link (1.12-compat)** — recognize inline Dataview fields inside blockquotes (`> [up:: [[Note]]]`) and wrapped fields appearing mid-sentence rather than only at the start of a line (`... is a child of (up:: [[Note]])`). Continues the 4.14.3-beta.1 backport (#724).
+
 ### [4.14.3-beta.1](https://github.com/michaelpporter/breadcrumbs/compare/4.14.2...4.14.3-beta.1) (2026-07-05)
 
 ### Bug Fixes

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "breadcrumbs",
 	"name": "Breadcrumbs",
-	"version": "4.14.2",
+	"version": "4.14.3-beta.1",
 	"minAppVersion": "1.12.3",
 	"description": "Add structured hierarchies to your notes.",
 	"author": "MichaelPPorter",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "breadcrumbs",
 	"name": "Breadcrumbs",
-	"version": "4.14.3-beta.1",
+	"version": "4.14.3-beta.2",
 	"minAppVersion": "1.12.3",
 	"description": "Add structured hierarchies to your notes.",
 	"author": "MichaelPPorter",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "breadcrumbs",
-	"version": "4.14.3-beta.1",
+	"version": "4.14.3-beta.2",
 	"description": "Add typed-links to your Obsidian notes",
 	"main": "main.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "breadcrumbs",
-	"version": "4.14.2",
+	"version": "4.14.3-beta.1",
 	"description": "Add typed-links to your Obsidian notes",
 	"main": "main.js",
 	"scripts": {

--- a/src/graph/builders/explicit/typed_link.ts
+++ b/src/graph/builders/explicit/typed_link.ts
@@ -6,9 +6,11 @@ import { resolve_relative_target_path } from "src/utils/obsidian";
 import { GCEdgeData, GCNodeData } from "wasm/pkg/breadcrumbs_graph_wasm";
 
 // Matches Dataview-style inline fields at the start of a line:
-//   [optional list marker] field-name:: rest-of-line
-// Supports: "same:: ...", "- same:: ...", "up :: ..." etc.
-const INLINE_FIELD_REGEX = /^(?:\s*[-*+\d.]+\s+)?([\w][\w\s-]*)\s*::\s*/;
+//   [optional list marker] [optional ( or [ wrapper] field-name:: rest-of-line
+// Supports: "same:: ...", "- same:: ...", "up :: ...",
+// and Dataview's bracket/paren wrappers "(down:: ...)" / "[down:: ...]".
+const INLINE_FIELD_REGEX =
+	/^(?:\s*[-*+\d.]+\s+)?[([]?\s*([\w][\w\s-]*)\s*::\s*/;
 
 /**
  * **typed_link** — the primary edge builder.

--- a/src/graph/builders/explicit/typed_link.ts
+++ b/src/graph/builders/explicit/typed_link.ts
@@ -6,11 +6,16 @@ import { resolve_relative_target_path } from "src/utils/obsidian";
 import { GCEdgeData, GCNodeData } from "wasm/pkg/breadcrumbs_graph_wasm";
 
 // Matches Dataview-style inline fields at the start of a line:
-//   [optional list marker] [optional ( or [ wrapper] field-name:: rest-of-line
-// Supports: "same:: ...", "- same:: ...", "up :: ...",
+//   [optional blockquote marker] [optional list marker] [optional ( or [ wrapper] field-name:: rest-of-line
+// Supports: "same:: ...", "- same:: ...", "up :: ...", "> same:: ...",
 // and Dataview's bracket/paren wrappers "(down:: ...)" / "[down:: ...]".
-const INLINE_FIELD_REGEX =
-	/^(?:\s*[-*+\d.]+\s+)?[([]?\s*([\w][\w\s-]*)\s*::\s*/;
+const LINE_START_FIELD_REGEX =
+	/^(?:\s*>+\s*)?(?:\s*[-*+\d.]+\s+)?[([]?\s*([\w][\w\s-]*)\s*::\s*/;
+
+// Matches Dataview's bracket/paren-wrapped inline fields anywhere within a
+// line of prose, e.g. "This note is a child of (up:: [[Note]])." — Dataview
+// only recognizes these mid-line when wrapped, unlike the line-start form.
+const WRAPPED_FIELD_REGEX = /[([]\s*([\w][\w\s-]*)\s*::\s*/g;
 
 /**
  * **typed_link** — the primary edge builder.
@@ -93,10 +98,29 @@ export const _add_explicit_edges_typed_link: ExplicitEdgeBuilder = async (
 				for (const link_cache of cache.links) {
 					const line_num = link_cache.position.start.line;
 					const line_text = lines[line_num] ?? "";
-					const match = INLINE_FIELD_REGEX.exec(line_text);
-					if (!match) continue;
 
-					const field = match[1].trim();
+					const start_match = LINE_START_FIELD_REGEX.exec(line_text);
+					let field: string | undefined = start_match?.[1]?.trim();
+
+					if (!field) {
+						// Fall back to the nearest wrapped field preceding the
+						// link on this line (mid-sentence inline annotations).
+						const before_link = line_text.slice(
+							0,
+							link_cache.position.start.col,
+						);
+						WRAPPED_FIELD_REGEX.lastIndex = 0;
+						let wrapped_match: RegExpExecArray | null;
+						let last: RegExpExecArray | undefined;
+						while (
+							(wrapped_match = WRAPPED_FIELD_REGEX.exec(before_link))
+						) {
+							last = wrapped_match;
+						}
+						field = last?.[1]?.trim();
+					}
+
+					if (!field) continue;
 					if (!field_labels.has(field)) continue;
 					if (fm_covered.has(`${field}\0${link_cache.link}`)) continue;
 

--- a/tests/graph/builders/helpers.ts
+++ b/tests/graph/builders/helpers.ts
@@ -23,7 +23,7 @@ export function mock_file(
 		/** Markdown list items (list_note builder): one per line */
 		listItems?: { line: number; col: number; parent: number }[];
 		/** Body wikilinks keyed by line (list_note builder) */
-		links?: { line: number; link: string }[];
+		links?: { line: number; col?: number; link: string }[];
 	} = {},
 ) {
 	const slash_path = path.replace(/\\/g, "/");
@@ -66,8 +66,8 @@ export function mock_file(
 				links: opts.links?.map((l) => ({
 					link: l.link,
 					position: {
-						start: { line: l.line, col: 0, offset: 0 },
-						end: { line: l.line, col: 0, offset: 0 },
+						start: { line: l.line, col: l.col ?? 0, offset: 0 },
+						end: { line: l.line, col: l.col ?? 0, offset: 0 },
 					},
 				})),
 			}

--- a/tests/graph/builders/typed_link.test.ts
+++ b/tests/graph/builders/typed_link.test.ts
@@ -1,6 +1,6 @@
 import { _add_explicit_edges_typed_link } from "src/graph/builders/explicit/typed_link";
 import { TFile } from "obsidian";
-import { describe, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { make_all_files, make_plugin, mock_file } from "./helpers";
 
 function mock_tfile(path: string): TFile {
@@ -108,6 +108,47 @@ describe("typed_link builder — Obsidian branch", () => {
 		t.expect(r.edges).toHaveLength(2);
 		t.expect(sources).toContain("a.md");
 		t.expect(sources).toContain("b.md");
+	});
+});
+
+// ---- Body inline-field branch ----
+
+/** Build a plugin whose cachedRead returns `body` for any file. */
+function inline_plugin(body: string) {
+	return make_plugin(
+		{ edge_fields: ["up", "down", "same"].map((l) => ({ label: l })) },
+		[],
+		undefined,
+		{ cachedRead: async () => body },
+	);
+}
+
+describe("typed_link builder — body inline fields", () => {
+	test.each([
+		["plain", "down:: [[Convolutions]]"],
+		["list marker", "- down:: [[Convolutions]]"],
+		["space before ::", "down :: [[Convolutions]]"],
+		["paren wrapper", "- (down:: [[Convolutions]])"],
+		["paren wrapper, no space", "- (down::[[Convolutions]])"],
+		["bracket wrapper", "- [down:: [[Convolutions]]]"],
+	])("detects inline field — %s", async (_label, line) => {
+		const files = [mock_file("a.md", { links: [{ line: 0, link: "Convolutions" }] })];
+		const r = await _add_explicit_edges_typed_link(
+			inline_plugin(line),
+			make_all_files(files),
+		);
+		expect(r.edges, `no edge for: ${line}`).toHaveLength(1);
+		expect(r.edges[0]!.edge_type, line).toBe("down");
+		expect(r.edges[0]!.target).toBe("Convolutions.md");
+	});
+
+	test("field not in edge_fields → no edge", async (t) => {
+		const files = [mock_file("a.md", { links: [{ line: 0, link: "X" }] })];
+		const r = await _add_explicit_edges_typed_link(
+			inline_plugin("(unknown:: [[X]])"),
+			make_all_files(files),
+		);
+		t.expect(r.edges).toHaveLength(0);
 	});
 });
 

--- a/tests/graph/builders/typed_link.test.ts
+++ b/tests/graph/builders/typed_link.test.ts
@@ -150,5 +150,35 @@ describe("typed_link builder — body inline fields", () => {
 		);
 		t.expect(r.edges).toHaveLength(0);
 	});
+
+	test("blockquote-wrapped field at line start", async (t) => {
+		const line = "> [up:: [[Note]]]";
+		const files = [
+			mock_file("a.md", {
+				links: [{ line: 0, col: line.indexOf("[[Note]]"), link: "Note" }],
+			}),
+		];
+		const r = await _add_explicit_edges_typed_link(
+			inline_plugin(line),
+			make_all_files(files),
+		);
+		expect(r.edges).toHaveLength(1);
+		expect(r.edges[0]!.edge_type).toBe("up");
+	});
+
+	test("wrapped field mid-sentence (not at line start)", async (t) => {
+		const line = "This other note is a child of (up:: [[Note]]).";
+		const files = [
+			mock_file("a.md", {
+				links: [{ line: 0, col: line.indexOf("[[Note]]"), link: "Note" }],
+			}),
+		];
+		const r = await _add_explicit_edges_typed_link(
+			inline_plugin(line),
+			make_all_files(files),
+		);
+		expect(r.edges).toHaveLength(1);
+		expect(r.edges[0]!.edge_type).toBe("up");
+	});
 });
 


### PR DESCRIPTION
## Summary
- Backports the 4.15.1 fix for inline Dataview properties to the 1.12-compat branch, targeting users still on Obsidian < 1.13.
- The inline-field regex now matches Dataview's `(down:: [[Note]])` / `[down:: [[Note]]]` wrappers, not just bare `down:: [[Note]]`, restoring explicit edges from inline fields.
- Fixes #724

## Test plan
- [x] `bun run test tests/graph/builders/typed_link.test.ts` — 15 passed
- [x] `bun run test` — 249 passed
- [x] `bun run build` — succeeds