### PR TITLE
fix(typed-link): scope inline Dataview fields to their bracket span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* Inline Dataview fields no longer claim links that sit outside them ([#731](https://github.com/michaelpporter/breadcrumbs/issues/731)). `(down:: [[y]]) [[x]]` in `x.md` used to make **both** `[[y]]` and `[[x]]` `down` children — including a self-loop from the note to itself — because the builder attributed every link on a line to whichever field opened that line. Bracketed fields now end at their closing bracket, matching Dataview, so only `[[y]]` becomes an edge and links elsewhere on the line stay ordinary prose. Multiple fields on one line (`(up:: [[p]]) (down:: [[c]])`) are also parsed separately now. Bare line-level fields (`down:: [[y]], [[x]]`) are unchanged — their value is still the rest of the line.
+
 ## 4.X
 
 ### [4.21.1](https://github.com/michaelpporter/breadcrumbs/compare/4.21.0...4.21.1) (2026-07-05)

--- a/src/graph/builders/explicit/typed_link.ts
+++ b/src/graph/builders/explicit/typed_link.ts
@@ -5,21 +5,92 @@ import type {
 import { resolve_relative_target_path } from "src/utils/obsidian";
 import { GCEdgeData, GCNodeData } from "wasm/pkg/breadcrumbs_graph_wasm";
 
-// Matches Dataview-style inline fields at the start of a line:
-//   [optional list marker] [optional ( or [ wrapper] field-name:: rest-of-line
-// Supports: "same:: ...", "- same:: ...", "up :: ...",
-// and Dataview's bracket/paren wrappers "(down:: ...)" / "[down:: ...]".
-const INLINE_FIELD_REGEX =
-	/^(?:\s*[-*+\d.]+\s+)?[([]?\s*([\w][\w\s-]*)\s*::\s*/;
+/** A Dataview inline field found on a line, with the span its value occupies. */
+export type InlineField = {
+	field: string;
+	/** Column of the first character of the value (inclusive). */
+	value_start: number;
+	/** Column just past the last character of the value (exclusive). */
+	value_end: number;
+};
+
+// A bare inline field opening a line: "same:: ...", "- same:: ...", "up :: ...".
+// Its value runs to the end of the line.
+const LINE_FIELD_REGEX = /^(?:\s*[-*+\d.]+\s+)?([\w][\w\s-]*)\s*::\s*/;
+
+// Dataview's bracket/paren wrappers, anywhere on the line: "(down:: ...)" /
+// "[down:: ...]". The value ends at the matching close bracket.
+const WRAPPED_FIELD_REGEX = /[([]\s*([\w][\w\s-]*)\s*::\s*/g;
 
 /**
- * Parse the field name from a line that opens with a Dataview-style inline
- * field (`field:: ...`). Pure over a single line — returns the trimmed field
- * name, or `null` when the line does not open with an inline field.
+ * Index of the bracket closing the one at `open_index`, or `line.length` when
+ * unclosed. Counts depth of that bracket type only, so nested wikilinks
+ * (`[down:: [[X]]]`) and markdown links (`(down:: [X](y))`) close correctly.
  */
-export const parse_inline_field = (line: string): string | null => {
-	const match = INLINE_FIELD_REGEX.exec(line);
-	return match ? match[1].trim() : null;
+const find_close_bracket = (line: string, open_index: number): number => {
+	const open = line[open_index]!;
+	const close = open === "(" ? ")" : "]";
+
+	let depth = 0;
+	for (let i = open_index; i < line.length; i++) {
+		if (line[i] === open) depth++;
+		else if (line[i] === close && --depth === 0) return i;
+	}
+
+	return line.length;
+};
+
+/**
+ * Parse every Dataview-style inline field on a line, along with the span of
+ * text that forms each one's value. Pure over a single line.
+ */
+export const parse_inline_fields = (line: string): InlineField[] => {
+	const fields: InlineField[] = [];
+
+	const line_match = LINE_FIELD_REGEX.exec(line);
+	if (line_match) {
+		fields.push({
+			field: line_match[1].trim(),
+			value_start: line_match[0].length,
+			value_end: line.length,
+		});
+	}
+
+	WRAPPED_FIELD_REGEX.lastIndex = 0;
+	let wrapped_match: RegExpExecArray | null;
+	while ((wrapped_match = WRAPPED_FIELD_REGEX.exec(line))) {
+		fields.push({
+			field: wrapped_match[1].trim(),
+			value_start: wrapped_match.index + wrapped_match[0].length,
+			value_end: find_close_bracket(line, wrapped_match.index),
+		});
+	}
+
+	return fields;
+};
+
+/**
+ * The field whose value contains column `col`, or `null` when the column falls
+ * outside every field. Ties go to the narrowest span, so a wrapped field wins
+ * over a bare line-level field that happens to enclose it.
+ */
+const field_at_column = (
+	fields: InlineField[],
+	col: number,
+): string | null => {
+	let best: InlineField | null = null;
+
+	for (const field of fields) {
+		if (col < field.value_start || col >= field.value_end) continue;
+		if (
+			!best ||
+			field.value_end - field.value_start < best.value_end - best.value_start
+		) {
+			best = field;
+		}
+	}
+
+	return best?.field ?? null;
 };
 
 /**
@@ -89,10 +160,21 @@ export const _add_explicit_edges_typed_link: ExplicitEdgeBuilder = async (
 				const content = await plugin.app.vault.cachedRead(file);
 				const lines = content.split("\n");
 
+				const fields_by_line = new Map<number, InlineField[]>();
+
 				for (const link_cache of cache.links) {
 					const line_num = link_cache.position.start.line;
-					const line_text = lines[line_num] ?? "";
-					const field = parse_inline_field(line_text);
+
+					let fields = fields_by_line.get(line_num);
+					if (!fields) {
+						fields = parse_inline_fields(lines[line_num] ?? "");
+						fields_by_line.set(line_num, fields);
+					}
+
+					const field = field_at_column(
+						fields,
+						link_cache.position.start.col,
+					);
 					if (!field) continue;
 					if (!field_labels.has(field)) continue;
 

--- a/tests/graph/builders/helpers.ts
+++ b/tests/graph/builders/helpers.ts
@@ -22,8 +22,8 @@ export function mock_file(
 		frontmatterLinks?: { key: string; link: string }[];
 		/** Markdown list items (list_note builder): one per line */
 		listItems?: { line: number; col: number; parent: number }[];
-		/** Body wikilinks keyed by line (list_note builder) */
-		links?: { line: number; link: string }[];
+		/** Body wikilinks keyed by line (list_note, typed_link builders) */
+		links?: { line: number; link: string; col?: number }[];
 		/** Headings (list_note section scoping): one per line */
 		headings?: { line: number; level: number; heading: string }[];
 	} = {},
@@ -69,8 +69,8 @@ export function mock_file(
 				links: opts.links?.map((l) => ({
 					link: l.link,
 					position: {
-						start: { line: l.line, col: 0, offset: 0 },
-						end: { line: l.line, col: 0, offset: 0 },
+						start: { line: l.line, col: l.col ?? 0, offset: 0 },
+						end: { line: l.line, col: l.col ?? 0, offset: 0 },
 					},
 				})),
 				headings: opts.headings?.map((h) => ({

--- a/tests/graph/builders/typed_link.test.ts
+++ b/tests/graph/builders/typed_link.test.ts
@@ -1,6 +1,6 @@
 import {
 	_add_explicit_edges_typed_link,
-	parse_inline_field,
+	parse_inline_fields,
 } from "src/graph/builders/explicit/typed_link";
 import { TFile } from "obsidian";
 import { describe, expect, test } from "vitest";
@@ -126,33 +126,104 @@ function inline_plugin(body: string) {
 	);
 }
 
+/**
+ * Scan a body for `[[wikilinks]]`, producing the cache.links entries Obsidian
+ * would — including the column each link starts at, which the builder uses to
+ * decide which inline field's value the link belongs to.
+ */
+function scan_links(body: string) {
+	return body.split("\n").flatMap((line, line_num) =>
+		[...line.matchAll(/\[\[([^\]|#]+)(?:[|#][^\]]*)?\]\]/g)].map((m) => ({
+			line: line_num,
+			col: m.index,
+			link: m[1]!,
+		})),
+	);
+}
+
+/** A single-file vault whose only note, `a.md`, has `body` as its content. */
+function inline_case(body: string) {
+	return {
+		plugin: inline_plugin(body),
+		all_files: make_all_files([
+			mock_file("a.md", { links: scan_links(body) }),
+		]),
+	};
+}
+
 describe("typed_link builder — body inline fields", () => {
 	// One integration case proving the builder wires
-	// parse_inline_field → resolve → edge. The regex matrix itself is
-	// covered directly by the parse_inline_field tests below.
+	// parse_inline_fields → resolve → edge. The regex matrix itself is
+	// covered directly by the parse_inline_fields tests below.
 	test("detects inline field and builds edge", async () => {
-		const line = "- down:: [[Convolutions]]";
-		const files = [mock_file("a.md", { links: [{ line: 0, link: "Convolutions" }] })];
-		const r = await _add_explicit_edges_typed_link(
-			inline_plugin(line),
-			make_all_files(files),
-		);
+		const { plugin, all_files } = inline_case("- down:: [[Convolutions]]");
+		const r = await _add_explicit_edges_typed_link(plugin, all_files);
+
 		expect(r.edges).toHaveLength(1);
 		expect(r.edges[0]!.edge_type).toBe("down");
 		expect(r.edges[0]!.target).toBe("Convolutions.md");
 	});
 
 	test("field not in edge_fields → no edge", async (t) => {
-		const files = [mock_file("a.md", { links: [{ line: 0, link: "X" }] })];
-		const r = await _add_explicit_edges_typed_link(
-			inline_plugin("(unknown:: [[X]])"),
-			make_all_files(files),
-		);
+		const { plugin, all_files } = inline_case("(unknown:: [[X]])");
+		const r = await _add_explicit_edges_typed_link(plugin, all_files);
+
 		t.expect(r.edges).toHaveLength(0);
+	});
+
+	// #731: a link trailing a wrapped inline field is ordinary prose, not part
+	// of the field's value.
+	test("link after a wrapped field → only the wrapped link becomes an edge", async (t) => {
+		const { plugin, all_files } = inline_case("(down:: [[y]]) [[x]]");
+		const r = await _add_explicit_edges_typed_link(plugin, all_files);
+
+		t.expect(r.edges).toHaveLength(1);
+		t.expect(r.edges[0]!.target).toBe("y.md");
+	});
+
+	test("link before a wrapped field → no edge", async (t) => {
+		const { plugin, all_files } = inline_case("[[x]] (down:: [[y]])");
+		const r = await _add_explicit_edges_typed_link(plugin, all_files);
+
+		t.expect(r.edges).toHaveLength(1);
+		t.expect(r.edges[0]!.target).toBe("y.md");
+	});
+
+	test("two wrapped fields on one line → each link gets its own field", async (t) => {
+		const { plugin, all_files } = inline_case("(up:: [[p]]) (down:: [[c]])");
+		const r = await _add_explicit_edges_typed_link(plugin, all_files);
+
+		t.expect(
+			r.edges.map((e) => [e.edge_type, e.target]),
+		).toEqual([
+			["up", "p.md"],
+			["down", "c.md"],
+		]);
+	});
+
+	test("bare line-level field still claims every link on the line", async (t) => {
+		const { plugin, all_files } = inline_case("down:: [[y]], [[x]]");
+		const r = await _add_explicit_edges_typed_link(plugin, all_files);
+
+		t.expect(r.edges.map((e) => e.target)).toEqual(["y.md", "x.md"]);
+	});
+
+	test("multi-line body → links resolve against their own line", async (t) => {
+		const { plugin, all_files } = inline_case(
+			"# Note\n\nsome prose [[z]]\n\n(down:: [[y]]) [[x]]",
+		);
+		const r = await _add_explicit_edges_typed_link(plugin, all_files);
+
+		t.expect(r.edges).toHaveLength(1);
+		t.expect(r.edges[0]!.target).toBe("y.md");
 	});
 });
 
-describe("parse_inline_field", () => {
+describe("parse_inline_fields", () => {
+	/** The first field name found on the line, or null. */
+	const first_field = (line: string) =>
+		parse_inline_fields(line)[0]?.field ?? null;
+
 	test.each([
 		["plain", "down:: [[Convolutions]]", "down"],
 		["dash list marker", "- down:: [[X]]", "down"],
@@ -170,7 +241,7 @@ describe("parse_inline_field", () => {
 		["field name with internal spaces", "my field:: [[X]]", "my field"],
 		["prose prefix before ::", "some text down:: [[X]]", "some text down"],
 	])("returns field name — %s", (_label, line, expected) => {
-		expect(parse_inline_field(line)).toBe(expected);
+		expect(first_field(line)).toBe(expected);
 	});
 
 	test.each([
@@ -180,7 +251,47 @@ describe("parse_inline_field", () => {
 		["plain prose", "just a normal sentence"],
 		["empty line", ""],
 	])("returns null — %s", (_label, line) => {
-		expect(parse_inline_field(line)).toBeNull();
+		expect(first_field(line)).toBeNull();
+	});
+
+	/** The substring each parsed field claims as its value. */
+	const values = (line: string) =>
+		parse_inline_fields(line).map((f) =>
+			line.slice(f.value_start, f.value_end),
+		);
+
+	test("bare field claims the rest of the line", () => {
+		expect(values("- down:: [[y]] and [[x]]")).toEqual(["[[y]] and [[x]]"]);
+	});
+
+	test("wrapped field stops at its closing bracket", () => {
+		expect(values("(down:: [[y]]) [[x]]")).toEqual(["[[y]]"]);
+	});
+
+	test("bracket wrapper closes past the nested wikilink", () => {
+		expect(values("[down:: [[y]]] [[x]]")).toEqual(["[[y]]"]);
+	});
+
+	test("markdown link inside a paren wrapper closes correctly", () => {
+		expect(values("(down:: [y](y.md)) [[x]]")).toEqual(["[y](y.md)"]);
+	});
+
+	test("unclosed wrapper falls back to the rest of the line", () => {
+		expect(values("(down:: [[y]]")).toEqual(["[[y]]"]);
+	});
+
+	test("multiple wrapped fields are all returned", () => {
+		const line = "(up:: [[p]]) (down:: [[c]])";
+
+		expect(
+			parse_inline_fields(line).map((f) => [
+				f.field,
+				line.slice(f.value_start, f.value_end),
+			]),
+		).toEqual([
+			["up", "[[p]]"],
+			["down", "[[c]]"],
+		]);
 	});
 });
 


### PR DESCRIPTION
Refs #731 — intentionally not an auto-closing keyword; the issue is closed when the fix ships in a release.

## Problem

Pass 2 of the `typed_link` builder (body inline fields) worked at **line granularity**: it asked "does this line open with an inline field?" and then attributed *every* link on that line to it.

So `(down:: [[y]]) [[x]]` in `x.md` made both `[[y]]` **and** `[[x]]` `down` children — including a self-loop from the note to itself.

## Fix

`parse_inline_field` (name only) becomes `parse_inline_fields`, which returns every field on the line plus the character span its value occupies, following Dataview's actual grammar:

- **Wrapped** — `(down:: …)` / `[down:: …]` anywhere on the line; the value ends at the matching close bracket.
- **Bare** — `down:: …` at line start (optionally after a list marker); the value runs to end of line, unchanged.

Links are then assigned by column, and a link falling outside every span produces no edge.

`find_close_bracket` counts depth of only the opening bracket's own type, so nested wikilinks (`[down:: [[X]]]`) and markdown links (`(down:: [y](y.md))`) close correctly. An unclosed wrapper falls back to end-of-line.

## Behaviour change

Prose links merely *near* an inline field no longer create edges. That's the correct Dataview reading, but a vault relying on `(down:: [[y]]) [[x]]` linking both would now need `down:: [[y]] [[x]]`.

## Tests

`bun run build && bun run test` pass. The existing mock gave every link `col: 0`, which the old code never read — `mock_file`'s `links` now takes an optional `col` (defaulting to 0, so `list_note` tests are unaffected), and a `scan_links` helper derives real columns from the body text so builder tests mirror what Obsidian's cache supplies.

New cases: the #731 repro, link-before-field, two wrapped fields on one line, bare field still claiming the whole line, multi-line bodies, and span assertions for nested/unclosed brackets.
