### PR TITLE
chore(deps): ignore TypeScript major bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,13 @@ updates:
     groups:
       js-dependencies:
         patterns: ["*"]
+    ignore:
+      # TypeScript 7 is not supported by svelte-check or typescript-eslint yet.
+      # The bump was merged once and broke `bun run build` on main; reverted in
+      # PR #741. Drop this entry only after confirming both tools claim TS7
+      # support -- minor/patch updates within v6 still come through.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   # Rust/WASM graph engine
   - package-ecosystem: "cargo"


### PR DESCRIPTION
TypeScript 7 is not yet supported by `svelte-check` or `typescript-eslint`. The bump was merged once inside a grouped dependency PR and broke `bun run build` on `main`, where it sat undetected from 2026-05-28 to 2026-07-25; reverted in PR #741.

Grouped PRs (`patterns: ["*"]`) are exactly how it slipped through — a single breaking dependency is easy to miss among a dozen others. Dependabot applies `ignore` rules *before* grouping, so `typescript` is now filtered out of the set entirely rather than needing to be spotted in review.

Scoped to `version-update:semver-major`, so 6.x minor and patch updates still come through normally. Remove this entry only after confirming both tools claim TS7 support.

Refs #741