### PR TITLE
ci(deps): cover 1.12-compat with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,3 +42,46 @@ updates:
     groups:
       github-actions:
         patterns: ["*"]
+
+  # 1.12-compat: a permanent parallel release line (Obsidian 1.12.x), never
+  # merged into main -- Dependabot reads config from the default branch only,
+  # so this branch gets no updates unless targeted explicitly here. See #748
+  # for the advisory gap this leaves today.
+  - package-ecosystem: "bun"
+    directory: "/"
+    target-branch: "1.12-compat"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      js-dependencies:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "cargo"
+    directory: "/wasm"
+    target-branch: "1.12-compat"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      cargo-dependencies:
+        patterns: ["*"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "1.12-compat"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci(deps)"
+    groups:
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
Dependabot reads its config from the default branch only. Since 1.12-compat is a permanent parallel release line that is never merged into `main`, it has never received a dependency update — confirmed: zero Dependabot PRs have ever targeted it.

Adds `target-branch: 1.12-compat` entries for all three ecosystems, mirroring `main`'s groups and the TypeScript major-version ignore from #749.

This is part of what the advisory gap in #748 reflects (16 on 1.12-compat vs 8 on main) — that branch has been getting no updates at all, not just missing `overrides` pins.

Refs #748